### PR TITLE
Add copy trait to () in tutorial to avoid compilation issue.

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -145,6 +145,7 @@ impl Inventory {
 ```
 type () {
     #layout(size = 0, align = 1);
+    wellknown_traits(Copy);
 }
 
 type crate::Inventory {


### PR DESCRIPTION
Without this trait, the following errors are emitted when going through the tutorial:

```
In file included from main.cpp:1:
././generated.h:2021:20: error: no member named 'drop_flag' in 'rust::Tuple<>'
            if (!t.drop_flag) {
                 ~ ^
././generated.h:2029:15: error: no member named 'drop_flag' in 'rust::Tuple<>'
            t.drop_flag = true;
            ~ ^
././generated.h:2035:15: error: no member named 'drop_flag' in 'rust::Tuple<>'
            t.drop_flag = false;
            ~ ^
3 errors generated.
```