### PR TITLE
Add support for Path aliases

### DIFF
--- a/examples/osmium/main.zng
+++ b/examples/osmium/main.zng
@@ -8,6 +8,8 @@
     #include <osmium/visitor.hpp>
 "
 
+use ::std::string::String as String;
+
 type str {
     wellknown_traits(?Sized);
 
@@ -23,10 +25,10 @@ type ::std::option::Option<&str> {
     constructor Some(&str);
 }
 
-type ::std::string::String {
+type String  {
     #layout(size = 24, align = 8);
 
-    fn new() -> ::std::string::String;
+    fn new() -> String;
     fn push_str(&mut self, &str);
 }
 
@@ -38,7 +40,7 @@ type crate::Reader {
     #cpp_value "0" "::osmium::io::Reader";
 }
 
-type ::std::result::Result<crate::Reader, ::std::string::String> {
+type ::std::result::Result<crate::Reader, String> {
     #layout(size = 24, align = 8);
 
     constructor Ok(crate::Reader);
@@ -74,7 +76,7 @@ type crate::Flags {
 }
 
 extern "C++" {
-    fn new_reader(crate::Flags) -> ::std::result::Result<crate::Reader, ::std::string::String>;
+    fn new_reader(crate::Flags) -> ::std::result::Result<crate::Reader, String>;
     
     impl crate::Reader {
         fn apply(&self, crate::BendHandler);
@@ -99,6 +101,6 @@ extern "C++" {
 
     impl crate::Node {
         fn distance(&self, &crate::Node) -> f64;
-        fn href(&self) -> ::std::string::String;
+        fn href(&self) -> String;
     }
 }

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -45,6 +45,7 @@ pub struct ZngurExternCppImpl {
     pub methods: Vec<ZngurMethod>,
 }
 
+#[derive(Debug)]
 pub struct ZngurConstructor {
     pub name: Option<String>,
     pub inputs: Vec<(String, RustType)>,
@@ -85,12 +86,14 @@ pub enum LayoutPolicy {
     OnlyByRef,
 }
 
+#[derive(Debug)]
 pub struct ZngurMethodDetails {
     pub data: ZngurMethod,
     pub use_path: Option<Vec<String>>,
     pub deref: Option<RustType>,
 }
 
+#[derive(Debug)]
 pub struct ZngurType {
     pub ty: RustType,
     pub layout: LayoutPolicy,
@@ -102,12 +105,13 @@ pub struct ZngurType {
     pub cpp_ref: Option<String>,
 }
 
+#[derive(Debug)]
 pub struct ZngurTrait {
     pub tr: RustTrait,
     pub methods: Vec<ZngurMethod>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ZngurFile {
     pub types: Vec<ZngurType>,
     pub traits: HashMap<RustTrait, ZngurTrait>,


### PR DESCRIPTION
- path expansion changed to consider aliases first
- aliases with relative paths expand using the base local to their use not the base local to their definition

also, the addition of a `Process` stage will allow working on things like  
- processing and merging multiple files,
- warning on undefined type reference in the fields and functions
- templates?
```rust
type<T> ::std::option::Option<T> {
    #layout(size = {T.size}, align = {T.align})
}

type<T,E> ::std::result::Result<T, E> {
    #layout(size = {max(T.size, E.size)}, align = {max(T.align, E.align)})
}

type<T> crate::SomeWrapper<T> {
    #layout(size = {T.size + 12}, align = 8)
}