### PR TITLE
Generate Merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-a.out
+a.out*
 .vscode
 compile_commands.json
 zngur-autozng/doc.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,10 @@ name = "example-simple"
 version = "0.6.0"
 
 [[package]]
+name = "example-simple-merged"
+version = "0.6.0"
+
+[[package]]
 name = "example-tutorial"
 version = "0.6.0"
 

--- a/examples/simple_merge/.gitignore
+++ b/examples/simple_merge/.gitignore
@@ -1,0 +1,3 @@
+generated.h
+generated.rs
+generated.cpp

--- a/examples/simple_merge/Cargo.toml
+++ b/examples/simple_merge/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-simple-merged"
+version = "0.6.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/simple_merge/Makefile
+++ b/examples/simple_merge/Makefile
@@ -1,0 +1,10 @@
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_simple_merged.a
+	${CXX} -Werror main.cpp generated.cpp -g -L ../../target/release/ -l example_simple_merged
+
+../../target/release/libexample_simple_merged.a: FORCE
+	cargo build --release
+
+generated.h generated.cpp ./src/generated.rs: one.zng two.zng
+	cd ../../zngur-cli && cargo run gm ../examples/simple_merge/one.zng ../examples/simple_merge/two.zng --in ../examples/simple_merge
+
+FORCE: ;

--- a/examples/simple_merge/README.md
+++ b/examples/simple_merge/README.md
@@ -1,0 +1,10 @@
+# Example: Simple
+
+A derivation of the `simple` example to demonstrate the `generate_merged` functionality - splits the `simple` example into two zng files to demonstrate semantic merging.
+
+To run this example:
+
+```
+make
+./a.out
+```

--- a/examples/simple_merge/main.cpp
+++ b/examples/simple_merge/main.cpp
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <vector>
+
+#include "./generated.h"
+
+// Rust values are available in the `::rust` namespace from their absolute path
+// in Rust
+template <typename T> using Vec = rust::std::vec::Vec<T>;
+template <typename T> using Option = rust::std::option::Option<T>;
+template <typename T> using BoxDyn = rust::Box<rust::Dyn<T>>;
+
+// You can implement Rust traits for your classes
+template <typename T>
+class VectorIterator : public rust::std::iter::Iterator<T> {
+  std::vector<T> vec;
+  size_t pos;
+
+public:
+  VectorIterator(std::vector<T> &&v) : vec(v), pos(0) {}
+  ~VectorIterator() {
+    std::cout << "vector iterator has been destructed" << std::endl;
+  }
+
+  Option<T> next() override {
+    if (pos >= vec.size()) {
+      return Option<T>::None();
+    }
+    T value = vec[pos++];
+    // You can construct Rust enum with fields in C++
+    return Option<T>::Some(value);
+  }
+};
+
+int main() {
+  // You can call Rust functions that return things by value, and store that
+  // value in your stack.
+  auto s = Vec<int32_t>::new_();
+  s.push(2);
+  Vec<int32_t>::push(s, 5);
+  s.push(7);
+  Vec<int32_t>::push(s, 3);
+  // You can call Rust functions just like normal Rust.
+  std::cout << s.clone().into_iter().sum() << std::endl;
+  // You can catch Rust panics as C++ exceptions
+  try {
+    std::cout << "s[2] = " << *s.get(2).unwrap() << std::endl;
+    std::cout << "s[4] = " << *s.get(4).unwrap() << std::endl;
+  } catch (rust::Panic e) {
+    std::cout << "Rust panic happened" << std::endl;
+  }
+  int state = 0;
+  // You can convert a C++ lambda into a `Box<dyn Fn>` and friends.
+  auto f = BoxDyn<rust::Fn<int32_t, int32_t>>::make_box([&](int32_t x) {
+    state += x;
+    std::cout << "hello " << x << " " << state << "\n";
+    return x * 2;
+  });
+  // And pass it to Rust functions that accept closures.
+  auto x = s.into_iter().map(std::move(f)).sum();
+  std::cout << x << " " << state << "\n";
+  std::vector<int32_t> vec{10, 20, 60};
+  // You can convert a C++ type that implements `Trait` to a `Box<dyn Trait>`.
+  // `make_box` is similar to the `make_unique`, it takes constructor arguments
+  // and construct it inside the `Box` (instead of `unique_ptr`).
+  auto vec_as_iter = BoxDyn<rust::std::iter::Iterator<int32_t>>::make_box<
+      VectorIterator<int32_t>>(std::move(vec));
+  // Then use it like a normal Rust value.
+  auto t = vec_as_iter.collect();
+  // Some utilities are also provided. For example, `zngur_dbg` is the
+  // equivalent of `dbg!` macro.
+  zngur_dbg(t);
+}

--- a/examples/simple_merge/one.zng
+++ b/examples/simple_merge/one.zng
@@ -1,0 +1,49 @@
+#convert_panic_to_exception
+
+type Box<dyn Fn(i32) -> i32> {
+    #layout(size = 16, align = 8);
+}
+
+mod ::std {
+    type option::Option<i32> {
+        #layout(size = 8, align = 4);
+        wellknown_traits(Copy);
+
+        constructor None;
+        constructor Some(i32);
+    }
+
+    type option::Option<&i32> {
+        #layout(size = 8, align = 8);
+        wellknown_traits(Copy);
+
+        fn unwrap(self) -> &i32;
+    }
+
+    type iter::Map<::std::vec::IntoIter<i32>, Box<dyn Fn(i32) -> i32>> {
+        #layout(size = 48, align = 8);
+
+        fn sum<i32>(self) -> i32;
+    }
+
+    mod vec {
+        type IntoIter<i32> {
+            #layout(size = 32, align = 8);
+
+            fn sum<i32>(self) -> i32;
+        }
+
+        type Vec<i32> {
+            #layout(size = 24, align = 8);
+            wellknown_traits(Debug);
+
+            fn new() -> Vec<i32>;
+            fn push(&mut self, i32);
+            fn clone(&self) -> Vec<i32>;
+        }
+    }
+
+    trait iter::Iterator::<Item = i32> {
+        fn next(&mut self) -> ::std::option::Option<i32>;
+    }
+}

--- a/examples/simple_merge/src/lib.rs
+++ b/examples/simple_merge/src/lib.rs
@@ -1,0 +1,2 @@
+#[rustfmt::skip]
+mod generated;

--- a/examples/simple_merge/two.zng
+++ b/examples/simple_merge/two.zng
@@ -1,0 +1,38 @@
+type Box<dyn Fn(i32) -> i32> {
+    #layout(size = 16, align = 8);
+}
+
+mod ::std {
+    type option::Option<i32> {
+        #layout(size = 8, align = 4);
+        fn unwrap(self) -> i32;
+    }
+
+    mod vec {
+        type IntoIter<i32> {
+            #layout(size = 32, align = 8);
+
+            fn sum<i32>(self) -> i32;
+            fn map<i32, Box<dyn Fn(i32) -> i32>>(self, Box<dyn Fn(i32) -> i32>)
+                -> ::std::iter::Map<::std::vec::IntoIter<i32>, Box<dyn Fn(i32) -> i32>>;
+        }
+
+        type Vec<i32> {
+            #layout(size = 24, align = 8);
+            wellknown_traits(Debug);
+
+            fn get(&self, usize) -> ::std::option::Option<&i32> deref [i32];
+            fn into_iter(self) -> ::std::vec::IntoIter<i32>;
+        }
+    }
+
+    trait iter::Iterator::<Item = i32> {
+        fn next(&mut self) -> ::std::option::Option<i32>;
+    }
+}
+
+type Box<dyn ::std::iter::Iterator<Item = i32>> {
+    #layout(size = 16, align = 8);
+
+    fn collect<::std::vec::Vec<i32>>(self) -> ::std::vec::Vec<i32>;
+}

--- a/zngur-cli/src/main.rs
+++ b/zngur-cli/src/main.rs
@@ -8,6 +8,12 @@ use zngur::Zngur;
 enum Command {
     #[command(alias = "g")]
     Generate { path: PathBuf },
+    #[command(alias = "gm")]
+    GenerateMerged {
+        paths: Vec<PathBuf>,
+        #[arg(long)]
+        r#in: PathBuf,
+    },
 }
 
 fn main() {
@@ -20,6 +26,16 @@ fn main() {
                 .with_h_file(pp.join("generated.h"))
                 .with_rs_file(pp.join("src/generated.rs"))
                 .generate();
+        }
+        Command::GenerateMerged {
+            paths,
+            r#in: in_dir,
+        } => {
+            Zngur::from_zng_files(paths)
+                .with_cpp_file(in_dir.join("generated.cpp"))
+                .with_h_file(in_dir.join("generated.h"))
+                .with_rs_file(in_dir.join("src/generated.rs"))
+                .generate_merged();
         }
     }
 }

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -101,7 +101,7 @@ pub struct ZngurTrait {
 
 #[derive(Default)]
 pub struct ZngurFile {
-    pub types: Vec<ZngurType>,
+    pub types: HashMap<RustType, ZngurType>,
     pub traits: HashMap<RustTrait, ZngurTrait>,
     pub funcs: Vec<ZngurFn>,
     pub extern_cpp_funcs: Vec<ZngurExternCppFn>,

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -2,6 +2,9 @@ use std::{collections::HashMap, fmt::Display};
 
 use itertools::Itertools;
 
+mod merge;
+pub use merge::{Merge, MergeFailure, MergeResult};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Mutability {
     Mut,
@@ -45,6 +48,7 @@ pub struct ZngurExternCppImpl {
     pub methods: Vec<ZngurMethod>,
 }
 
+#[derive(PartialEq, Eq)]
 pub struct ZngurConstructor {
     pub name: Option<String>,
     pub inputs: Vec<(String, RustType)>,
@@ -78,6 +82,7 @@ pub enum LayoutPolicy {
     OnlyByRef,
 }
 
+#[derive(PartialEq, Eq)]
 pub struct ZngurMethodDetails {
     pub data: ZngurMethod,
     pub use_path: Option<Vec<String>>,
@@ -100,14 +105,20 @@ pub struct ZngurTrait {
 }
 
 #[derive(Default)]
+pub struct AdditionalIncludes(pub String);
+
+#[derive(Default)]
+pub struct ConvertPanicToException(pub bool);
+
+#[derive(Default)]
 pub struct ZngurFile {
     pub types: HashMap<RustType, ZngurType>,
     pub traits: HashMap<RustTrait, ZngurTrait>,
     pub funcs: Vec<ZngurFn>,
     pub extern_cpp_funcs: Vec<ZngurExternCppFn>,
     pub extern_cpp_impls: Vec<ZngurExternCppImpl>,
-    pub additional_includes: String,
-    pub convert_panic_to_exception: bool,
+    pub additional_includes: AdditionalIncludes,
+    pub convert_panic_to_exception: ConvertPanicToException,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -1,0 +1,137 @@
+use crate::{
+    AdditionalIncludes, ConvertPanicToException, ZngurExternCppFn, ZngurExternCppImpl, ZngurFile,
+    ZngurFn, ZngurTrait, ZngurType,
+};
+use std::vec::Vec;
+
+pub trait Merge<T = Self> {
+    fn merge(self, into: &mut T) -> MergeResult;
+}
+
+pub enum MergeFailure {
+    Conflict(String),
+}
+
+pub type MergeResult = Result<(), MergeFailure>;
+
+fn push_unique<T: Eq>(item: T, smallvec: &mut Vec<T>) {
+    if !smallvec.contains(&item) {
+        smallvec.push(item);
+    }
+}
+
+fn merge_unique<T: Eq>(other: Vec<T>, smallvec: &mut Vec<T>) {
+    for item in other {
+        push_unique(item, smallvec);
+    }
+}
+
+impl<K, V, I: IntoIterator<Item = (K, V)>> Merge<std::collections::HashMap<K, V>> for I
+where
+    K: Eq + std::hash::Hash,
+    V: Merge,
+{
+    fn merge(self, into: &mut std::collections::HashMap<K, V>) -> MergeResult {
+        for (key, value) in self {
+            match into.entry(key) {
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(value);
+                }
+                std::collections::hash_map::Entry::Occupied(mut e) => {
+                    match value.merge(e.get_mut()) {
+                        Ok(()) => {}
+                        Err(message) => {
+                            return Err(message);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Merge for ZngurType {
+    fn merge(self, into: &mut Self) -> MergeResult {
+        if self.ty != into.ty {
+            panic!(
+                "Attempt to merge different types: {} and {}",
+                self.ty, into.ty
+            );
+        }
+
+        if self.layout != into.layout {
+            return Err(MergeFailure::Conflict("Layout mismatch".to_string()));
+        }
+
+        merge_unique(self.wellknown_traits, &mut into.wellknown_traits);
+        merge_unique(self.methods, &mut into.methods);
+        merge_unique(self.constructors, &mut into.constructors);
+        // TODO: cpp_value, cpp_ref
+
+        Ok(())
+    }
+}
+
+impl Merge for ZngurTrait {
+    fn merge(self, into: &mut Self) -> MergeResult {
+        if self.tr != into.tr {
+            panic!(
+                "Attempt to merge different traits: {} and {}",
+                self.tr, into.tr
+            );
+        }
+
+        merge_unique(self.methods, &mut into.methods);
+
+        Ok(())
+    }
+}
+
+impl Merge<ZngurFile> for ZngurType {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        [(self.ty.clone(), self)].merge(&mut into.types)
+    }
+}
+
+impl Merge<ZngurFile> for ZngurTrait {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        [(self.tr.clone(), self)].merge(&mut into.traits)
+    }
+}
+
+impl Merge<ZngurFile> for ZngurFn {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        push_unique(self, &mut into.funcs);
+        Ok(())
+    }
+}
+
+impl Merge<ZngurFile> for ZngurExternCppFn {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        push_unique(self, &mut into.extern_cpp_funcs);
+        Ok(())
+    }
+}
+
+impl Merge<ZngurFile> for ZngurExternCppImpl {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        push_unique(self, &mut into.extern_cpp_impls);
+        Ok(())
+    }
+}
+
+impl Merge<ZngurFile> for AdditionalIncludes {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        into.additional_includes.0 += self.0.as_str();
+        Ok(())
+    }
+}
+
+impl Merge<ZngurFile> for ConvertPanicToException {
+    fn merge(self, into: &mut ZngurFile) -> MergeResult {
+        // REVISIT: Should we just set to true here?
+        into.convert_panic_to_exception.0 |= self.0;
+        Ok(())
+    }
+}

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -46,14 +46,14 @@ impl ZngurGenerator {
             },
         );
         let mut cpp_file = CppFile::default();
-        cpp_file.additional_includes = zng.additional_includes;
+        cpp_file.additional_includes = zng.additional_includes.0;
         let mut rust_file = RustFile::default();
         cpp_file.trait_defs = zng
             .traits
             .iter()
             .map(|(key, value)| (key.clone(), rust_file.add_builder_for_dyn_trait(value)))
             .collect();
-        if zng.convert_panic_to_exception {
+        if zng.convert_panic_to_exception.0 {
             rust_file.enable_panic_to_exception();
             cpp_file.panic_to_exception = true;
         }

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -525,7 +525,7 @@ static LATEST_FILENAME: Mutex<String> = Mutex::new(String::new());
 static LATEST_TEXT: Mutex<String> = Mutex::new(String::new());
 
 impl ParsedZngFile<'_> {
-    pub fn parse(filename: &str, text: &str) -> ZngurFile {
+    pub fn parse_into(zngur: &mut ZngurFile, filename: &str, text: &str) {
         *LATEST_FILENAME.lock().unwrap() = filename.to_string();
         *LATEST_TEXT.lock().unwrap() = text.to_string();
         let (tokens, errs) = lexer().parse(text).into_output_errors();
@@ -544,15 +544,16 @@ impl ParsedZngFile<'_> {
             let errs = errs.into_iter().map(|e| e.map_token(|c| c.to_string()));
             emit_error(errs);
         };
-        ast.0.into_zngur_file()
+
+        for item in ast.0.0 {
+            item.add_to_zngur_file(zngur, &[]);
+        }
     }
 
-    pub fn into_zngur_file(self) -> ZngurFile {
-        let mut r = ZngurFile::default();
-        for item in self.0 {
-            item.add_to_zngur_file(&mut r, &[]);
-        }
-        r
+    pub fn parse(filename: &str, text: &str) -> ZngurFile {
+        let mut zngur = ZngurFile::default();
+        Self::parse_into(&mut zngur, filename, text);
+        zngur
     }
 }
 

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -324,15 +324,19 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                         ty.span,
                     );
                 };
-                r.types.push(ZngurType {
-                    ty: ty.inner.to_zngur(base),
-                    layout,
-                    methods,
-                    wellknown_traits: wt,
-                    constructors,
-                    cpp_value,
-                    cpp_ref,
-                });
+                let ty = ty.inner.to_zngur(base);
+                r.types.insert(
+                    ty.clone(),
+                    ZngurType {
+                        ty,
+                        layout,
+                        methods,
+                        wellknown_traits: wt,
+                        constructors,
+                        cpp_value,
+                        cpp_ref,
+                    },
+                );
             }
             ParsedItem::Trait { tr, methods } => {
                 let tr = tr.to_zngur(base);

--- a/zngur/src/lib.rs
+++ b/zngur/src/lib.rs
@@ -104,6 +104,16 @@ impl Zngur {
     }
 
     pub fn generate_merged(self) {
-        todo!()
+        let mut zngur = zngur_generator::ZngurFile::default();
+        for path in &self.zng_files {
+            let file = std::fs::read_to_string(&path).unwrap();
+            ParsedZngFile::parse_into(
+                &mut zngur,
+                path.file_name().unwrap().to_str().unwrap(),
+                &file,
+            );
+        }
+        let file = ZngurGenerator::build_from_zng(zngur);
+        self.emit(file);
     }
 }


### PR DESCRIPTION
Adds a `gm` command which takes arbitrarily many `.zng` files and a required `--in` flag which indicates where the generated files should be placed.

This work should be considered a draft for architecture review by @HKalbasi - before spending more time improving error messages and thinking about semantic edge cases, I wanted to see if this passes the smell test.

See `examples/example-simple-merged` to get a sense of how it works. Entities are semantically merged at the parsing stage - unless entities conflict (e.g different layout specs), their fields are merged in predictable ways: usually, that means a union of things like methods, constructors, fields, etc. 