### PR TITLE
Fix ci dependency tracking

### DIFF
--- a/examples/memory_management/Makefile
+++ b/examples/memory_management/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_memory_management.a: FORCE
 	cargo build --release
 
-generated.h generated.cpp ./src/generated.rs: main.zng
+generated.h generated.cpp ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/memory_management/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/multiple_zngur_files/Makefile
+++ b/examples/multiple_zngur_files/Makefile
@@ -17,3 +17,6 @@ generated2.h ./src/generated2.rs: main.zng
 		--cpp-namespace=m2
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/raw_pointer/Makefile
+++ b/examples/raw_pointer/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_raw_pointer.a: FORCE
 	cargo build --release
 
-generated.h ./src/generated.rs: main.zng
+generated.h ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/raw_pointer/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/rayon/Makefile
+++ b/examples/rayon/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_rayon.a: FORCE
 	cargo build --release
 
-generated.h ./src/generated.rs: main.zng
+generated.h ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/rayon/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/regression_test1/Makefile
+++ b/examples/regression_test1/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_regression_test1.a: FORCE
 	cargo build --release
 
-generated.h ./src/generated.rs: main.zng
+generated.h ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/regression_test1/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/rustyline/Makefile
+++ b/examples/rustyline/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_rustyline.a: FORCE
 	cargo build --release
 
-generated.h ./src/generated.rs: main.zng
+generated.h ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/rustyline/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_simple.a: FORCE
 	cargo build --release
 
-generated.h generated.cpp ./src/generated.rs: main.zng
+generated.h generated.cpp ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/simple/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/simple_import/Makefile
+++ b/examples/simple_import/Makefile
@@ -8,3 +8,6 @@ a.out: main.cpp foo.cpp bar.cpp generated.h src/generated.rs src/lib.rs ../../ta
 
 generated.h ./src/generated.rs: main.zng primitives.zng foo.zng bar.zng
 	cd ../../zngur-cli && cargo run g ../examples/simple_import/main.zng
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/tutorial-wasm32/Makefile
+++ b/examples/tutorial-wasm32/Makefile
@@ -53,3 +53,6 @@ clean:
 install-deps: wasm32-wasip1-target
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/tutorial/Makefile
+++ b/examples/tutorial/Makefile
@@ -4,7 +4,10 @@ a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/lib
 ../../target/release/libexample_tutorial.a: FORCE
 	cargo build --release
 
-generated.h ./src/generated.rs: main.zng
+generated.h ./src/generated.rs: main.zng FORCE
 	cd ../../zngur-cli && cargo run g ../examples/tutorial/main.zng
 
 FORCE: ;
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -29,7 +29,6 @@ fn check_examples(sh: &Shell, fix: bool) -> Result<()> {
                 "rm -f generated.h generated.cpp src/generated.rs actual_output.txt"
             )
             .run();
-            cmd!(sh, "cargo clean").run()?;
             cmd!(sh, "cargo build")
                 .run()
                 .with_context(|| format!("Building example `{example}` failed"))?;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -21,7 +21,15 @@ fn check_examples(sh: &Shell, fix: bool) -> Result<()> {
     let examples = cmd!(sh, "ls").read()?;
     for example in examples.lines() {
         sh.change_dir(example);
+
         if CARGO_PROJECTS.contains(&example) {
+            // Clean generated files for Cargo projects
+            let _ = cmd!(
+                sh,
+                "rm -f generated.h generated.cpp src/generated.rs actual_output.txt"
+            )
+            .run();
+            cmd!(sh, "cargo clean").run()?;
             cmd!(sh, "cargo build")
                 .run()
                 .with_context(|| format!("Building example `{example}` failed"))?;
@@ -30,6 +38,10 @@ fn check_examples(sh: &Shell, fix: bool) -> Result<()> {
                 .run()
                 .with_context(|| format!("Running example `{example}` failed"))?;
         } else {
+            // Clean generated files for Make projects
+            cmd!(sh, "make clean")
+                .run()
+                .with_context(|| format!("Cleaning example `{example}` failed"))?;
             cmd!(sh, "make")
                 .run()
                 .with_context(|| format!("Building example `{example}` failed"))?;


### PR DESCRIPTION
## Prevent false negatives from stale generated files

The CI system had a critical flaw where `cargo xtask ci` would use stale generated files instead of regenerating them when generator source code changed. Makefiles only tracked `main.zng` changes, so when you modified `cpp.rs` or other sources, `make` would skip regeneration and tests would pass using old generated files while your changes went untested.

The fix adds `clean` targets to all makefiles and modifies CI to run `make clean` before building each example, forcing fresh generation every time. I also added `FORCE` dependencies to generation rules and handled both Make-based and Cargo-based examples properly. Now any changes to the code generation pipeline are immediately tested, eliminating the false positive problem and ensuring local CI behavior matches what actually gets tested.