### PR TITLE
Template type definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-template-types"
+version = "0.7.0"
+
+[[package]]
 name = "example-tutorial"
 version = "0.10.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 # Exclude tutorial-wasm32 from default workspace builds since it requires extra dependencies
 exclude = [
     "examples/tutorial-wasm32",
+    "examples/multiple_zngur_files",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
 # Exclude tutorial-wasm32 from default workspace builds since it requires extra dependencies
 exclude = [
     "examples/tutorial-wasm32",
-    "examples/multiple_zngur_files",
 ]
 resolver = "2"
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Types with special support](./call_rust_from_cpp/special_types.md)
   - [Panic and exceptions](./call_rust_from_cpp/panic_and_exceptions.md)
   - [Raw pointers](./call_rust_from_cpp/raw_pointers.md)
+  - [Template types](./template_types.md)
 - [Calling C++ from Rust](./call_cpp_from_rust/index.md)
   - [Calling C++ free functions](./call_cpp_from_rust/function.md)
   - [Writing `impl` blocks for Rust types in C++](./call_cpp_from_rust/rust_impl.md)

--- a/book/src/template_types.md
+++ b/book/src/template_types.md
@@ -1,6 +1,6 @@
 # Template types
 
-Template type definitions provide a shorthand syntax to avoid repeating the defintion of methods on common generic types. All of the items within a template type definition are copied into each matching concrete type definition. At the moment, template types are considered unstable and ust be activated with the `#unstable(template_types)` directive.
+Template type definitions provide a shorthand syntax to avoid repeating the definition of methods on common generic types. All of the items within a template type definition are copied into each matching concrete type definition. At the moment, template types are considered unstable and ust be activated with the `#unstable(template_types)` directive.
 
 For example:
 ```
@@ -36,7 +36,7 @@ type<T> option::Option<&T> {
 }
 ```
 
-Note that multiple template defintions can apply to the same concrete type, so `Option<&i32>` would inherit definitions from the `Option<T>` template and the `Option<&T>` template.
+Note that multiple template definitions can apply to the same concrete type, so `Option<&i32>` would inherit definitions from the `Option<T>` template and the `Option<&T>` template.
 
 You can also override the layout given in a template:
 ```

--- a/book/src/template_types.md
+++ b/book/src/template_types.md
@@ -1,0 +1,65 @@
+# Template types
+
+Template type definitions provide a shorthand syntax to avoid repeating the defintion of methods on common generic types. All of the items within a template type definition are copied into each matching concrete type definition. At the moment, template types are considered unstable and ust be activated with the `#unstable(template_types)` directive.
+
+For example:
+```
+#unstable(template_types)
+
+type<T> ::std::option::Option<T> {
+    constructor Some(T);
+    constructor None;
+    fn unwrap(self) -> T;
+    fn is_some(&self) -> bool;
+}
+
+type ::std::option::Option<i32> {
+    #layout(size = 8, align = 8);
+    wellknown_traits(Copy, Debug);
+    // the constructors and methods are automatically defined
+}
+```
+
+You can also define well-known traits and layouts in template types:
+```
+type<T> [T] {
+    wellknown_traits(?Sized);
+}
+
+type<T> ::std::vec::Vec<T> {
+    #layout(size = 24, align = 8);
+}
+
+type<T> option::Option<&T> {
+    #layout(size = 8, align = 8);
+    wellknown_traits(Copy);
+}
+```
+
+Note that multiple template defintions can apply to the same concrete type, so `Option<&i32>` would inherit definitions from the `Option<T>` template and the `Option<&T>` template.
+
+You can also override the layout given in a template:
+```
+type<T> Box<T> {
+    #layout(size = 8, align = 8);
+    // Most Boxed types are 8 bytes
+}
+
+type<T> Box<i32> {} // Inherits the 8 byte layouts
+
+type Box<dyn crate::MyTrait> {
+    #layout(size = 16, align = 8);
+    // Boxed trait objects are 16 bytes
+}
+```
+
+Zngur will still only emit C++ definitions for the concrete types that are defined. Template definitions on their own do not result in any C++ code. This also means that at the moment, any type mentioned in a template definition must be individually defined as well. For example, the following code will fail to compile unless `Option<String>` is defined to make `Result::<String, i64>::ok` valid. If the `Option<T>` template from above is defined, then we must add a definition for `String` as well to support `Option::<String>::unwrap`.
+```
+type<T, E> ::std::result::Result<T, E> {
+    fn ok(self) -> ::std::option::Option<T>;
+}
+
+type ::std::result::Result<::std::string::String, i64> {
+    #layout(size = 24, align = 8);
+}
+```

--- a/book/src/template_types.md
+++ b/book/src/template_types.md
@@ -3,6 +3,7 @@
 Template type definitions provide a shorthand syntax to avoid repeating the definition of methods on common generic types. All of the items within a template type definition are copied into each matching concrete type definition. At the moment, template types are considered unstable and ust be activated with the `#unstable(template_types)` directive.
 
 For example:
+
 ```
 #unstable(template_types)
 
@@ -21,6 +22,7 @@ type ::std::option::Option<i32> {
 ```
 
 You can also define well-known traits and layouts in template types:
+
 ```
 type<T> [T] {
     wellknown_traits(?Sized);
@@ -39,6 +41,7 @@ type<T> option::Option<&T> {
 Note that multiple template definitions can apply to the same concrete type, so `Option<&i32>` would inherit definitions from the `Option<T>` template and the `Option<&T>` template.
 
 You can also override the layout given in a template:
+
 ```
 type<T> Box<T> {
     #layout(size = 8, align = 8);
@@ -54,6 +57,7 @@ type Box<dyn crate::MyTrait> {
 ```
 
 Zngur will still only emit C++ definitions for the concrete types that are defined. Template definitions on their own do not result in any C++ code. This also means that at the moment, any type mentioned in a template definition must be individually defined as well. For example, the following code will fail to compile unless `Option<String>` is defined to make `Result::<String, i64>::ok` valid. If the `Option<T>` template from above is defined, then we must add a definition for `String` as well to support `Option::<String>::unwrap`.
+
 ```
 type<T, E> ::std::result::Result<T, E> {
     fn ok(self) -> ::std::option::Option<T>;

--- a/examples/template_types/.gitignore
+++ b/examples/template_types/.gitignore
@@ -1,0 +1,6 @@
+generated.h
+generated.rs
+generated*.rs
+generated.cpp
+history.txt
+b.out

--- a/examples/template_types/Cargo.toml
+++ b/examples/template_types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-template-types"
+version = "0.7.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/template_types/Makefile
+++ b/examples/template_types/Makefile
@@ -1,0 +1,13 @@
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_template_types.a
+	${CXX} -std=c++20 -Werror main.cpp -g -L ../../target/release/ -l example_template_types
+
+../../target/release/libexample_template_types.a:
+	cargo build --release
+
+generated.h ./src/generated.rs: main.zng
+	cd ../../zngur-cli && cargo run g ../examples/template_types/main.zng
+
+.PHONY: ../../target/release/libexample_template_types.a generated.h clean
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/template_types/Makefile
+++ b/examples/template_types/Makefile
@@ -1,11 +1,11 @@
 a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_template_types.a
-	${CXX} -std=c++20 -Werror main.cpp -g -L ../../target/release/ -l example_template_types
+	${CXX} -std=c++20 -Werror -I. main.cpp -g -L ../../target/release/ -l example_template_types
 
 ../../target/release/libexample_template_types.a:
 	cargo build --release
 
 generated.h ./src/generated.rs: main.zng
-	cd ../../zngur-cli && cargo run g ../examples/template_types/main.zng
+	cd ../../zngur-cli && cargo run g -i ../examples/template_types/main.zng --crate-name "crate"
 
 .PHONY: ../../target/release/libexample_template_types.a generated.h clean
 

--- a/examples/template_types/README.md
+++ b/examples/template_types/README.md
@@ -1,0 +1,10 @@
+# Example: Template Types
+
+A example, used to demonstrate template type definitions
+
+To run this example:
+
+```
+make
+./a.out
+```

--- a/examples/template_types/expected_output.txt
+++ b/examples/template_types/expected_output.txt
@@ -1,4 +1,4 @@
-[main.cpp:11] vec_a = [
+[main.cpp:12] vec_a = [
     TypeA(
         1,
     ),
@@ -9,13 +9,13 @@
         3,
     ),
 ]
-[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:19] vec_b.get(i).unwrap() = TypeB(
     1,
 )
-[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:19] vec_b.get(i).unwrap() = TypeB(
     2,
 )
-[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:19] vec_b.get(i).unwrap() = TypeB(
     3,
 )
 Hello

--- a/examples/template_types/expected_output.txt
+++ b/examples/template_types/expected_output.txt
@@ -1,0 +1,21 @@
+[main.cpp:11] vec_a = [
+    TypeA(
+        1,
+    ),
+    TypeA(
+        2,
+    ),
+    TypeA(
+        3,
+    ),
+]
+[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+    1,
+)
+[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+    2,
+)
+[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+    3,
+)
+Hello

--- a/examples/template_types/expected_output.txt
+++ b/examples/template_types/expected_output.txt
@@ -1,4 +1,4 @@
-[main.cpp:12] vec_a = [
+[main.cpp:11] vec_a = [
     TypeA(
         1,
     ),
@@ -9,13 +9,13 @@
         3,
     ),
 ]
-[main.cpp:19] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
     1,
 )
-[main.cpp:19] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
     2,
 )
-[main.cpp:19] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
     3,
 )
 Hello

--- a/examples/template_types/main.cpp
+++ b/examples/template_types/main.cpp
@@ -1,0 +1,24 @@
+#include <cstddef>
+
+#include "generated.h"
+
+
+int main() {
+  auto vec_a = rust::std::vec::Vec<rust::crate::TypeA>::new_();
+  vec_a.push(rust::crate::TypeA(1));
+  vec_a.push(rust::crate::TypeA(2));
+  vec_a.push(rust::crate::TypeA(3));
+  // vec_a.get(0); // Does not exist because [TypeA] is not defined in main.zng
+  zngur_dbg(vec_a);
+
+  auto vec_b = rust::std::vec::Vec<rust::crate::TypeB>::new_();
+  vec_b.push(rust::crate::TypeB(1));
+  vec_b.push(rust::crate::TypeB(2));
+  vec_b.push(rust::crate::TypeB(3));
+  for (std::size_t i = 0; i < vec_b.len(); i++) {
+    zngur_dbg(vec_b.get(i).unwrap());
+  }
+
+  auto box = rust::crate::get_box();
+  box.as_ref().say_hello();
+}

--- a/examples/template_types/main.cpp
+++ b/examples/template_types/main.cpp
@@ -8,7 +8,6 @@ int main() {
   vec_a.push(rust::crate::TypeA(1));
   vec_a.push(rust::crate::TypeA(2));
   vec_a.push(rust::crate::TypeA(3));
-  // vec_a.get(0); // Does not exist because [TypeA] is not defined in main.zng
   zngur_dbg(vec_a);
 
   auto vec_b = rust::std::vec::Vec<rust::crate::TypeB>::new_();

--- a/examples/template_types/main.zng
+++ b/examples/template_types/main.zng
@@ -1,0 +1,72 @@
+#unstable(template_types)
+
+type<T> [T] {
+    wellknown_traits(?Sized);
+    fn get(&self, usize) -> ::std::option::Option<&T>;
+    fn len(&self) -> usize;
+}
+
+mod ::std {
+
+    type<T> option::Option<T> {
+        constructor Some(T);
+        constructor None;
+        fn unwrap(self) -> T;
+    }
+
+    type<T> option::Option<&T> {
+        #layout(size = 8, align = 8);
+        wellknown_traits(Copy);
+    }
+
+    type<T> vec::Vec<T> {
+        #layout(size = 24, align = 8);
+        fn new() -> vec::Vec<T>;
+        fn push(&mut self, T);
+        fn len(&self) -> usize;
+
+        fn get(&self, usize) -> option::Option<&T> deref [T];
+    }
+
+    type<T> boxed::Box<T> {
+        // Most Box<T> have the same layout, but not Box<dyn T>
+        #layout(size = 8, align = 8);
+        fn as_ref(&self) -> &T;
+    }
+}
+
+mod crate {
+
+    type TypeA {
+        #layout(size = 4, align = 4);
+        wellknown_traits(Debug);
+        constructor (i32);
+    }
+
+    type ::std::vec::Vec<TypeA> {
+        wellknown_traits(Debug);
+    }
+
+    type TypeB {
+        #layout(size = 4, align = 4);
+        wellknown_traits(Debug);
+        constructor (i32);
+    }
+
+    // All relevant definitions are provided by the templates
+    type ::std::vec::Vec<TypeB> {}
+    type [TypeB] {}
+    type ::std::option::Option<&TypeB> {}
+
+    type ::std::boxed::Box<dyn MyTrait> {
+        // Can override layout from templates
+        #layout(size = 16, align = 8);
+    }
+
+    type dyn MyTrait {
+        wellknown_traits(?Sized);
+        fn say_hello(&self);
+    }
+
+    fn get_box() -> ::std::boxed::Box<dyn MyTrait>;
+}

--- a/examples/template_types/main.zng
+++ b/examples/template_types/main.zng
@@ -46,8 +46,7 @@ mod crate {
     type ::std::vec::Vec<TypeA> {
         wellknown_traits(Debug);
     }
-    // These definitions are required for the Vec<T> template to instantiate all methods
-    type [TypeA] {}
+    // This definition is required for the Vec<T> template to instantiate all methods
     type ::std::option::Option<&TypeA> {} 
 
     type TypeB {
@@ -58,7 +57,6 @@ mod crate {
 
     // All relevant definitions are provided by the templates
     type ::std::vec::Vec<TypeB> {}
-    type [TypeB] {}
     type ::std::option::Option<&TypeB> {}
 
     type ::std::boxed::Box<dyn MyTrait> {

--- a/examples/template_types/main.zng
+++ b/examples/template_types/main.zng
@@ -46,6 +46,9 @@ mod crate {
     type ::std::vec::Vec<TypeA> {
         wellknown_traits(Debug);
     }
+    // These definitions are required for the Vec<T> template to instantiate all methods
+    type [TypeA] {}
+    type ::std::option::Option<&TypeA> {} 
 
     type TypeB {
         #layout(size = 4, align = 4);

--- a/examples/template_types/src/lib.rs
+++ b/examples/template_types/src/lib.rs
@@ -1,0 +1,21 @@
+#![allow(unused)]
+
+mod generated;
+
+#[derive(Debug)]
+struct TypeA(i32);
+
+#[derive(Debug)]
+struct TypeB(i32);
+
+trait MyTrait {
+    fn say_hello(&self) {
+        println!("Hello");
+    }
+}
+
+impl MyTrait for TypeA {}
+
+fn get_box() -> Box<dyn MyTrait> {
+    Box::new(TypeA(1))
+}

--- a/examples/template_types/src/lib.rs
+++ b/examples/template_types/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 
+#[rustfmt::skip]
 mod generated;
 
 #[derive(Debug)]

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -137,10 +137,10 @@ pub struct ZngurMethodDetails {
     pub deref: Option<(RustType, Mutability)>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CppValue(pub String, pub String);
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CppRef(pub String);
 
 #[derive(Debug, PartialEq, Eq)]

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -143,7 +143,7 @@ pub struct CppValue(pub String, pub String);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CppRef(pub String);
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CppStackOwned {
     pub cpp_type: String,
     pub size: usize,

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -159,7 +159,7 @@ impl Display for CppRef {
 #[derive(Debug)]
 pub struct ZngurType {
     pub ty: RustType,
-    pub layout: LayoutPolicy,
+    pub layout: Option<LayoutPolicy>,
     pub wellknown_traits: Vec<ZngurWellknownTrait>,
     pub methods: Vec<ZngurMethodDetails>,
     pub constructors: Vec<ZngurConstructor>,
@@ -238,6 +238,9 @@ pub enum PrimitiveRustType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TypeVar(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RustPathAndGenerics {
     pub path: Vec<String>,
     pub generics: Vec<RustType>,
@@ -255,6 +258,7 @@ pub enum RustType {
     Impl(RustTrait, Vec<String>),
     Tuple(Vec<RustType>),
     Adt(RustPathAndGenerics),
+    TypeVar(TypeVar),
 }
 
 impl RustType {
@@ -342,6 +346,7 @@ impl Display for RustType {
                 Ok(())
             }
             RustType::Slice(s) => write!(f, "[{s}]"),
+            RustType::TypeVar(TypeVar(v)) => write!(f, "{v}"),
         }
     }
 }

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -191,7 +191,6 @@ pub struct ModuleImport {
 
 #[derive(Debug, Default)]
 pub struct ZngurSpec {
-    pub imports: Vec<Import>,
     pub imported_modules: Vec<ModuleImport>,
     pub types: Vec<ZngurType>,
     pub traits: IndexMap<RustTrait, ZngurTrait>,

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -131,10 +131,12 @@ impl Merge for ZngurType {
             );
         }
 
-        if self.layout != into.layout {
+        if let (Some(layout1), Some(layout2)) = &(self.layout, into.layout) && layout1 != layout2 {
             return Err(MergeFailure::Conflict(
-                "Duplicate layout policy found".to_string(),
+                "Conflicitng layout policy found".to_string(),
             ));
+        } else {
+            into.layout = into.layout.or(self.layout);
         }
 
         // TODO: We need to improve the architecture around checking parsing, semantic, and other types of errors.

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -138,7 +138,7 @@ impl Merge for ZngurType {
         }
 
         // TODO: We need to improve the architecture around checking parsing, semantic, and other types of errors.
-        if self.cpp_ref.is_some() && into.layout != LayoutPolicy::ZERO_SIZED_TYPE {
+        if self.cpp_ref.is_some() && into.layout != Some(LayoutPolicy::ZERO_SIZED_TYPE) {
             return Err(MergeFailure::Conflict(
                 "cpp_ref implies a zero sized stack allocated type".to_string(),
             ));

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -131,7 +131,9 @@ impl Merge for ZngurType {
             );
         }
 
-        if let (Some(layout1), Some(layout2)) = &(self.layout, into.layout) && layout1 != layout2 {
+        if let (Some(layout1), Some(layout2)) = &(self.layout, into.layout)
+            && layout1 != layout2
+        {
             return Err(MergeFailure::Conflict(
                 "Conflicting layout policy found".to_string(),
             ));

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -133,7 +133,7 @@ impl Merge for ZngurType {
 
         if let (Some(layout1), Some(layout2)) = &(self.layout, into.layout) && layout1 != layout2 {
             return Err(MergeFailure::Conflict(
-                "Conflicitng layout policy found".to_string(),
+                "Conflictng layout policy found".to_string(),
             ));
         } else {
             into.layout = into.layout.or(self.layout);

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -133,7 +133,7 @@ impl Merge for ZngurType {
 
         if let (Some(layout1), Some(layout2)) = &(self.layout, into.layout) && layout1 != layout2 {
             return Err(MergeFailure::Conflict(
-                "Conflictng layout policy found".to_string(),
+                "Conflicting layout policy found".to_string(),
             ));
         } else {
             into.layout = into.layout.or(self.layout);

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -85,7 +85,14 @@ impl ZngurGenerator {
         for ty_def in zng.types {
             let ty = &ty_def.ty;
             let is_copy = ty_def.wellknown_traits.contains(&ZngurWellknownTrait::Copy);
-            match ty_def.layout {
+            let Some(layout) = ty_def.layout else {
+                panic!(
+                    "No layout policy found for type {}. \
+                        Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.",
+                    ty_def.ty
+                )
+            };
+            match layout {
                 LayoutPolicy::StackAllocated { size, align } => {
                     rust_file.add_static_size_assert(&ty, size);
                     rust_file.add_static_align_assert(&ty, align);

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -294,7 +294,7 @@ impl ZngurGenerator {
             }
             cpp_file.type_defs.push(CppTypeDefinition {
                 ty: ty.into_cpp(default_ns, &sanitized_crate_name),
-                layout: rust_file.add_layout_policy_shim(&ty, ty_def.layout),
+                layout: rust_file.add_layout_policy_shim(&ty, layout),
                 constructors,
                 fields,
                 methods: cpp_methods,

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -86,11 +86,7 @@ impl ZngurGenerator {
             let ty = &ty_def.ty;
             let is_copy = ty_def.wellknown_traits.contains(&ZngurWellknownTrait::Copy);
             let Some(layout) = ty_def.layout else {
-                panic!(
-                    "No layout policy found for type {}. \
-                        Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.",
-                    ty_def.ty
-                )
+                unreachable!("Every type should have a defined layout policy before rendering")
             };
             match layout {
                 LayoutPolicy::StackAllocated { size, align } => {

--- a/zngur-generator/src/rust.rs
+++ b/zngur-generator/src/rust.rs
@@ -143,7 +143,9 @@ impl IntoCpp for RustType {
                 }
             }
             RustType::Impl(_, _) => panic!("impl Trait is invalid in C++"),
-            RustType::TypeVar(_) => unreachable!("should not attempt to generate definition for unbound TypeVar")
+            RustType::TypeVar(_) => {
+                unreachable!("should not attempt to generate definition for unbound TypeVar")
+            }
         }
     }
 }

--- a/zngur-generator/src/rust.rs
+++ b/zngur-generator/src/rust.rs
@@ -143,6 +143,7 @@ impl IntoCpp for RustType {
                 }
             }
             RustType::Impl(_, _) => panic!("impl Trait is invalid in C++"),
+            RustType::TypeVar(_) => unreachable!("should not attempt to generate definition for unbound TypeVar")
         }
     }
 }

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fmt::Display, path::Component};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+    path::Component,
+};
 
 #[cfg(not(test))]
 use std::process::exit;
@@ -10,7 +14,7 @@ use itertools::{Either, Itertools};
 use zngur_def::{
     AdditionalIncludes, ConvertPanicToException, CppRef, CppStackOwned, CppValue, Import,
     LayoutPolicy, Merge, MergeFailure, ModuleImport, Mutability, PrimitiveRustType,
-    RustPathAndGenerics, RustTrait, RustType, ZngurConstructor, ZngurExternCppFn,
+    RustPathAndGenerics, RustTrait, RustType, TypeVar, ZngurConstructor, ZngurExternCppFn,
     ZngurExternCppImpl, ZngurField, ZngurFn, ZngurMethod, ZngurMethodDetails, ZngurMethodReceiver,
     ZngurSpec, ZngurTrait, ZngurType, ZngurWellknownTrait,
 };
@@ -107,6 +111,7 @@ struct ParsedPath<'a> {
 struct Scope<'a> {
     aliases: Vec<ParsedAlias<'a>>,
     base: Vec<String>,
+    type_vars: HashSet<ParsedTypeVar<'a>>,
 }
 
 impl<'a> Scope<'a> {
@@ -114,7 +119,8 @@ impl<'a> Scope<'a> {
     fn new_root(aliases: Vec<ParsedAlias<'a>>) -> Scope<'a> {
         Scope {
             aliases,
-            base: Vec::new(),
+            base: Default::default(),
+            type_vars: Default::default(),
         }
     }
 
@@ -149,6 +155,37 @@ impl<'a> Scope<'a> {
         Scope {
             aliases: mod_aliases,
             base,
+            type_vars: self.type_vars.clone(),
+        }
+    }
+
+    fn with_type_vars(&self, type_vars: HashSet<ParsedTypeVar<'a>>) -> Scope<'_> {
+        Scope {
+            aliases: self.aliases.clone(),
+            base: self.base.clone(),
+            type_vars,
+        }
+    }
+
+    fn as_type_var(&self, ty: &ParsedRustPathAndGenerics<'a>) -> Option<TypeVar> {
+        if let ParsedRustPathAndGenerics {
+            path:
+                ParsedPath {
+                    start: ParsedPathStart::Relative,
+                    segments,
+                    span: _,
+                },
+            generics,
+            named_generics,
+        } = ty
+            && generics.is_empty()
+            && named_generics.is_empty()
+            && let &[single_elem] = segments.as_slice()
+            && self.type_vars.contains(&ParsedTypeVar(single_elem))
+        {
+            Some(TypeVar(single_elem.to_owned()))
+        } else {
+            None
         }
     }
 }
@@ -242,6 +279,7 @@ enum ParsedItem<'a> {
     Type {
         ty: Spanned<ParsedRustType<'a>>,
         items: Vec<Spanned<ParsedTypeItem<'a>>>,
+        type_vars: Option<HashSet<ParsedTypeVar<'a>>>,
     },
     Trait {
         tr: Spanned<ParsedRustTrait<'a>>,
@@ -270,6 +308,7 @@ enum ProcessedItem<'a> {
     Type {
         ty: Spanned<ParsedRustType<'a>>,
         items: Vec<Spanned<ParsedTypeItem<'a>>>,
+        type_vars: Option<HashSet<ParsedTypeVar<'a>>>,
     },
     Trait {
         tr: Spanned<ParsedRustTrait<'a>>,
@@ -344,6 +383,9 @@ enum ParsedTypeItem<'a> {
     MatchOnCfg(Condition<CfgConditional<'a>, ParsedTypeItem<'a>, NItems>),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ParsedTypeVar<'a>(&'a str);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedMethod<'a> {
     name: &'a str,
@@ -385,7 +427,12 @@ where
 }
 
 impl ProcessedItem<'_> {
-    fn add_to_zngur_spec(self, r: &mut ZngurSpec, scope: &Scope<'_>, ctx: &mut ParseContext) {
+    fn add_to_zngur_spec(
+        self,
+        r: &mut ZngurSpecBuilder,
+        scope: &Scope<'_>,
+        ctx: &mut ParseContext,
+    ) {
         match self {
             ProcessedItem::Mod {
                 path,
@@ -414,7 +461,11 @@ impl ProcessedItem<'_> {
             ProcessedItem::ModuleImport { path, span: _ } => {
                 r.imported_modules.push(ModuleImport { path: path.clone() });
             }
-            ProcessedItem::Type { ty, items } => {
+            ProcessedItem::Type {
+                ty,
+                items,
+                type_vars,
+            } => {
                 if ty.inner == ParsedRustType::Tuple(vec![]) {
                     // We add unit type implicitly.
                     ctx.add_error_str(
@@ -422,6 +473,11 @@ impl ProcessedItem<'_> {
                         ty.span,
                     );
                 }
+
+                let (is_template, scope) = match type_vars {
+                    Some(type_vars) => (true, &scope.with_type_vars(type_vars)),
+                    None => (false, scope),
+                };
 
                 let mut methods = vec![];
                 let mut constructors = vec![];
@@ -632,30 +688,22 @@ impl ProcessedItem<'_> {
                     }
                     layout = Some(LayoutPolicy::OnlyByRef);
                 }
-                if let Some(layout) = layout {
-                    checked_merge(
-                        ZngurType {
-                            ty: ty.inner.to_zngur(scope),
-                            layout,
-                            methods,
-                            wellknown_traits: wt,
-                            constructors,
-                            fields,
-                            cpp_value,
-                            cpp_ref,
-                            cpp_stack_owned,
-                        },
-                        r,
-                        ty.span,
-                        ctx,
-                    );
-                } else {
-                    ctx.add_error_str(
-                        "No layout policy found for this type. \
-Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.",
-                        ty.span,
-                    );
+                let zngur_type = ZngurType {
+                    ty: ty.inner.to_zngur(scope),
+                    layout,
+                    methods,
+                    wellknown_traits: wt,
+                    constructors,
+                    fields,
+                    cpp_value,
+                    cpp_ref,
+                    cpp_stack_owned,
                 };
+                if is_template {
+                    r.templates.push(zngur_type);
+                } else {
+                    checked_merge(zngur_type, &mut r.spec, ty.span, ctx);
+                }
             }
             ProcessedItem::Trait { tr, methods } => {
                 checked_merge(
@@ -663,7 +711,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                         tr: tr.inner.to_zngur(scope),
                         methods: methods.into_iter().map(|m| m.to_zngur(scope)).collect(),
                     },
-                    r,
+                    &mut r.spec,
                     tr.span,
                     ctx,
                 );
@@ -680,7 +728,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                         inputs: method.inputs,
                         output: method.output,
                     },
-                    r,
+                    &mut r.spec,
                     f.span,
                     ctx,
                 );
@@ -698,7 +746,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                                     output: method.output,
                                     is_safe,
                                 },
-                                r,
+                                &mut r.spec,
                                 span,
                                 ctx,
                             );
@@ -717,7 +765,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                                         })
                                         .collect(),
                                 },
-                                r,
+                                &mut r.spec,
                                 ty.span,
                                 ctx,
                             );
@@ -726,7 +774,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                 }
             }
             ProcessedItem::CppAdditionalInclude(s) => {
-                match AdditionalIncludes(s.to_owned()).merge(r) {
+                match AdditionalIncludes(s.to_owned()).merge(&mut r.spec) {
                     Ok(()) => {}
                     Err(_) => {
                         unreachable!() // For now, additional includes can't have conflicts.
@@ -741,7 +789,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                     );
                     return;
                 }
-                match ConvertPanicToException(true).merge(r) {
+                match ConvertPanicToException(true).merge(&mut r.spec) {
                     Ok(()) => {}
                     Err(_) => {
                         unreachable!() // For now, CPtE also can't have conflicts.
@@ -784,7 +832,10 @@ impl ParsedRustType<'_> {
             ParsedRustType::Tuple(v) => {
                 RustType::Tuple(v.into_iter().map(|s| s.to_zngur(scope)).collect())
             }
-            ParsedRustType::Adt(s) => RustType::Adt(s.to_zngur(scope)),
+            ParsedRustType::Adt(s) => match scope.as_type_var(&s) {
+                Some(v) => RustType::TypeVar(v),
+                None => RustType::Adt(s.to_zngur(scope)),
+            },
         }
     }
 }
@@ -1014,7 +1065,11 @@ impl ImportResolver for DefaultImportResolver {
 }
 
 impl<'a> ParsedZngFile<'a> {
-    fn parse_into(zngur: &mut ZngurSpec, ctx: &mut ParseContext, resolver: &impl ImportResolver) {
+    fn parse_into(
+        zngur: &mut ZngurSpecBuilder,
+        ctx: &mut ParseContext,
+        resolver: &impl ImportResolver,
+    ) {
         let (tokens, errs) = lexer().parse(ctx.text).into_output_errors();
         let Some(tokens) = tokens else {
             ctx.add_errors(errs.into_iter().map(|e| e.map_token(|c| c.to_string())));
@@ -1074,8 +1129,8 @@ impl<'a> ParsedZngFile<'a> {
 
     /// Parse a .zng file and return both the spec and list of all processed files.
     pub fn parse(path: std::path::PathBuf, cfg: Box<dyn RustCfgProvider>) -> ParseResult {
-        let mut zngur = ZngurSpec::default();
-        zngur.rust_cfg.extend(cfg.get_cfg_pairs());
+        let mut zngur = ZngurSpecBuilder::default();
+        zngur.spec.rust_cfg.extend(cfg.get_cfg_pairs());
         let text = std::fs::read_to_string(&path).unwrap();
         let mut ctx = ParseContext::new(path.clone(), &text, cfg.clone_box());
         Self::parse_into(&mut zngur, &mut ctx, &DefaultImportResolver);
@@ -1102,21 +1157,21 @@ impl<'a> ParsedZngFile<'a> {
             ctx.emit_ariadne_errors();
         }
         ParseResult {
-            spec: zngur,
+            spec: zngur.to_zngur(),
             processed_files: ctx.processed_files,
         }
     }
 
     /// Parse a .zng file from a string. Mainly useful for testing.
     pub fn parse_str(text: &str, cfg: impl RustCfgProvider + 'static) -> ParseResult {
-        let mut zngur = ZngurSpec::default();
+        let mut zngur = ZngurSpecBuilder::default();
         let mut ctx = ParseContext::new(std::path::PathBuf::from("test.zng"), text, Box::new(cfg));
         Self::parse_into(&mut zngur, &mut ctx, &DefaultImportResolver);
         if ctx.has_errors() {
             ctx.emit_ariadne_errors();
         }
         ParseResult {
-            spec: zngur,
+            spec: zngur.to_zngur(),
             processed_files: ctx.processed_files,
         }
     }
@@ -1127,14 +1182,14 @@ impl<'a> ParsedZngFile<'a> {
         cfg: impl RustCfgProvider + 'static,
         resolver: &impl ImportResolver,
     ) -> ParseResult {
-        let mut zngur = ZngurSpec::default();
+        let mut zngur = ZngurSpecBuilder::default();
         let mut ctx = ParseContext::new(std::path::PathBuf::from("test.zng"), text, Box::new(cfg));
         Self::parse_into(&mut zngur, &mut ctx, resolver);
         if ctx.has_errors() {
             ctx.emit_ariadne_errors();
         }
         ParseResult {
-            spec: zngur,
+            spec: zngur.to_zngur(),
             processed_files: ctx.processed_files,
         }
     }
@@ -1174,7 +1229,15 @@ fn process_parsed_item<'a>(
                 aliases,
             })
         }
-        ParsedItem::Type { ty, items } => Ret::Processed(ProcessedItem::Type { ty, items }),
+        ParsedItem::Type {
+            ty,
+            items,
+            type_vars,
+        } => Ret::Processed(ProcessedItem::Type {
+            ty,
+            items,
+            type_vars,
+        }),
         ParsedItem::Trait { tr, methods } => Ret::Processed(ProcessedItem::Trait { tr, methods }),
         ParsedItem::Fn(method) => Ret::Processed(ProcessedItem::Fn(method)),
         ParsedItem::ExternCpp(items) => Ret::Processed(ProcessedItem::ExternCpp(items)),
@@ -1218,12 +1281,28 @@ impl<'a> ProcessedZngFile<'a> {
         ProcessedZngFile { aliases, items }
     }
 
-    fn into_zngur_spec(self, zngur: &mut ZngurSpec, ctx: &mut ParseContext) {
+    fn into_zngur_spec(self, zngur: &mut ZngurSpecBuilder, ctx: &mut ParseContext) {
         let root_scope = Scope::new_root(self.aliases);
 
         for item in self.items {
             item.add_to_zngur_spec(zngur, &root_scope, ctx);
         }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Import(pub std::path::PathBuf);
+
+#[derive(Default)]
+struct ZngurSpecBuilder {
+    spec: ZngurSpec,
+    templates: Vec<ZngurType>,
+    imports: Vec<Import>,
+}
+
+impl ZngurSpecBuilder {
+    fn to_zngur(self) -> ZngurSpec {
+        todo!()
     }
 }
 
@@ -1822,12 +1901,26 @@ fn type_item<'a>() -> impl Parser<'a, ParserInput<'a>, ParsedItem<'a>, ZngParser
     just(Token::KwType)
         .ignore_then(spanned(rust_type()))
         .then(
+            (select! { Token::Ident(c) => c })
+                .map(ParsedTypeVar)
+                .separated_by(just(Token::Comma))
+                .at_least(1)
+                .allow_trailing()
+                .collect()
+                .delimited_by(just(Token::AngleOpen), just(Token::AngleClose))
+                .or_not(),
+        )
+        .then(
             spanned(inner_type_item())
                 .repeated()
                 .collect::<Vec<_>>()
                 .delimited_by(just(Token::BraceOpen), just(Token::BraceClose)),
         )
-        .map(|(ty, items)| ParsedItem::Type { ty, items })
+        .map(|((ty, type_vars), items)| ParsedItem::Type {
+            ty,
+            items,
+            type_vars,
+        })
         .boxed()
 }
 

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -462,7 +462,7 @@ impl ProcessedItem<'_> {
                 }
             }
             ProcessedItem::ModuleImport { path, span: _ } => {
-                r.imported_modules.push(ModuleImport { path: path.clone() });
+                r.spec.imported_modules.push(ModuleImport { path: path.clone() });
             }
             ProcessedItem::Type {
                 ty,
@@ -1283,9 +1283,6 @@ impl<'a> ProcessedZngFile<'a> {
         }
     }
 }
-
-#[derive(Clone, Debug, Default)]
-struct Import(pub std::path::PathBuf);
 
 struct TemplateDef {
     ty: ZngurType,

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -702,6 +702,10 @@ impl ProcessedItem<'_> {
                         span: ty.span,
                     });
                 } else {
+                    r.ty_to_locations
+                        .entry(zngur_type.ty.clone())
+                        .or_default()
+                        .push((ctx.filename().to_owned(), ty.span.start..ty.span.end));
                     checked_merge(zngur_type, &mut r.spec, ty.span, ctx);
                 }
             }
@@ -966,13 +970,12 @@ impl<'a, 'b> ParseContext<'a, 'b> {
     }
 
     fn consume_from(&mut self, mut other: ParseContext<'_, 'b>) {
-        // Always merge processed files, regardless of errors
         self.processed_files.append(&mut other.processed_files);
-        if other.has_errors() {
-            self.reports.extend(other.reports);
-            self.source_cache.insert(other.path, other.text.to_string());
-            self.source_cache.extend(other.source_cache);
-        }
+        self.reports.extend(other.reports);
+        // Always cache the source in case errors come up in post-processing
+        self.source_cache.insert(other.path, other.text.to_string());
+        self.source_cache.extend(other.source_cache);
+
     }
 
     fn has_errors(&self) -> bool {
@@ -1295,6 +1298,7 @@ struct TemplateDef {
 struct ZngurSpecBuilder {
     spec: ZngurSpec,
     templates: Vec<TemplateDef>,
+    ty_to_locations: HashMap<RustType, Vec<(String, std::ops::Range<usize>)>>,
     imports: Vec<Import>,
 }
 
@@ -1304,13 +1308,19 @@ impl ZngurSpecBuilder {
             mut spec,
             templates,
             imports: _,
+            mut ty_to_locations,
         } = self;
         let defined_types = spec.types.iter().map(|ty| ty.ty.clone()).collect();
         for ty in &mut spec.types {
+            let mut template_locations = Vec::new();
             for template in &templates {
                 if let Some(template_match) =
                     try_match_template(&ty.ty, &template.ty, &defined_types)
                 {
+                    let location = (
+                        template.filename.clone(),
+                        template.span.start..template.span.end,
+                    );
                     if let Err(e) = template_match.merge(ty) {
                         let MergeFailure::Conflict(e) = e;
                         ctx.add_report(
@@ -1320,15 +1330,14 @@ impl ZngurSpecBuilder {
                                     template.ty.ty, ty.ty, e
                                 ))
                                 .with_label(
-                                    Label::new((
-                                        template.filename.clone(),
-                                        template.span.start..template.span.end,
-                                    ))
-                                    .with_message("Template defined here")
-                                    .with_color(Color::Blue),
+                                    Label::new(location)
+                                        .with_message("Template defined here")
+                                        .with_color(Color::Blue),
                                 )
                                 .finish(),
                         );
+                    } else {
+                        template_locations.push(location);
                     }
                 }
             }
@@ -1339,6 +1348,29 @@ impl ZngurSpecBuilder {
                 )
             }) {
                 ty.wellknown_traits.push(ZngurWellknownTrait::Drop);
+            }
+            if ty.layout.is_none() {
+                let mut report = Report::build(ReportKind::Error, "", 0)
+                    .with_message(format!(
+                        "No layout policy found for type {}. \
+    Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.",
+                        ty.ty
+                    ));
+                for location in ty_to_locations.remove(&ty.ty).unwrap_or_default() {
+                    report = report.with_label(
+                        Label::new(location)
+                            .with_message("Type defined here")
+                            .with_color(Color::Blue),
+                    );
+                }
+                for location in template_locations {
+                    report = report.with_label(
+                        Label::new(location)
+                            .with_message("Matching template defined here")
+                            .with_color(Color::Blue),
+                    );
+                }
+                ctx.add_report(report.finish());
             }
         }
         spec

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -1314,9 +1314,7 @@ impl ZngurSpecBuilder {
         for ty in &mut spec.types {
             let mut template_locations = Vec::new();
             for template in &templates {
-                if let Some(template_match) =
-                    try_match_template(&ty.ty, &template.ty)
-                {
+                if let Some(template_match) = try_match_template(&ty.ty, &template.ty) {
                     let location = (
                         template.filename.clone(),
                         template.span.start..template.span.end,

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -1131,6 +1131,7 @@ impl<'a> ParsedZngFile<'a> {
     pub fn parse(path: std::path::PathBuf, cfg: Box<dyn RustCfgProvider>) -> ParseResult {
         let mut zngur = ZngurSpecBuilder::default();
         zngur.spec.rust_cfg.extend(cfg.get_cfg_pairs());
+        zngur.spec.rust_cfg.sort();
         let text = std::fs::read_to_string(&path).unwrap();
         let mut ctx = ParseContext::new(path.clone(), &text, cfg.clone_box());
         Self::parse_into(&mut zngur, &mut ctx, &DefaultImportResolver);
@@ -1338,6 +1339,9 @@ impl ZngurSpecBuilder {
                 )
             }) {
                 ty.wellknown_traits.push(ZngurWellknownTrait::Drop);
+            }
+            if ty.layout.is_none() {
+                ctx.add_report(Report::build(kind, src_id, offset));
             }
         }
         spec

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 use std::process::exit;
 
 use ariadne::{Color, Label, Report, ReportKind, sources};
-use chumsky::prelude::*;
+use chumsky::{input::MapExtra, prelude::*};
 use itertools::{Either, Itertools};
 
 use zngur_def::{
@@ -40,6 +40,7 @@ mod template_types;
 use crate::{
     cfg::{CfgConditional, RustCfgProvider},
     conditional::{Condition, ConditionalItem, NItems, conditional_item},
+    template_types::try_match_template,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +64,7 @@ type ParserInput<'a> = chumsky::input::MappedInput<
 pub struct UnstableFeatures {
     pub cfg_match: bool,
     pub cfg_if: bool,
+    pub template_types: bool,
 }
 
 #[derive(Default)]
@@ -649,17 +651,10 @@ impl ProcessedItem<'_> {
                     .iter()
                     .find(|x| x.inner == ZngurWellknownTrait::Unsized)
                     .cloned();
-                let is_copy = wellknown_traits
-                    .iter()
-                    .find(|x| x.inner == ZngurWellknownTrait::Copy)
-                    .cloned();
-                let mut wt = wellknown_traits
+                let wt = wellknown_traits
                     .into_iter()
                     .map(|x| x.inner)
                     .collect::<Vec<_>>();
-                if is_copy.is_none() && is_unsized.is_none() {
-                    wt.push(ZngurWellknownTrait::Drop);
-                }
                 if let Some(is_unsized) = is_unsized {
                     if let Some(span) = layout_span {
                         ctx.add_report(
@@ -701,7 +696,11 @@ impl ProcessedItem<'_> {
                     cpp_stack_owned,
                 };
                 if is_template {
-                    r.templates.push(zngur_type);
+                    r.templates.push(TemplateDef {
+                        ty: zngur_type,
+                        filename: ctx.filename().to_owned(),
+                        span: ty.span,
+                    });
                 } else {
                     checked_merge(zngur_type, &mut r.spec, ty.span, ctx);
                 }
@@ -1135,6 +1134,7 @@ impl<'a> ParsedZngFile<'a> {
         let text = std::fs::read_to_string(&path).unwrap();
         let mut ctx = ParseContext::new(path.clone(), &text, cfg.clone_box());
         Self::parse_into(&mut zngur, &mut ctx, &DefaultImportResolver);
+        let spec = zngur.to_zngur(&mut ctx);
         if ctx.has_errors() {
             // add report of cfg values used
             ctx.add_report(
@@ -1158,23 +1158,15 @@ impl<'a> ParsedZngFile<'a> {
             ctx.emit_ariadne_errors();
         }
         ParseResult {
-            spec: zngur.to_zngur(),
+            spec,
             processed_files: ctx.processed_files,
         }
     }
 
     /// Parse a .zng file from a string. Mainly useful for testing.
+    #[cfg(test)]
     pub fn parse_str(text: &str, cfg: impl RustCfgProvider + 'static) -> ParseResult {
-        let mut zngur = ZngurSpecBuilder::default();
-        let mut ctx = ParseContext::new(std::path::PathBuf::from("test.zng"), text, Box::new(cfg));
-        Self::parse_into(&mut zngur, &mut ctx, &DefaultImportResolver);
-        if ctx.has_errors() {
-            ctx.emit_ariadne_errors();
-        }
-        ParseResult {
-            spec: zngur.to_zngur(),
-            processed_files: ctx.processed_files,
-        }
+        Self::parse_str_with_resolver(text, cfg, &DefaultImportResolver)
     }
 
     #[cfg(test)]
@@ -1186,11 +1178,12 @@ impl<'a> ParsedZngFile<'a> {
         let mut zngur = ZngurSpecBuilder::default();
         let mut ctx = ParseContext::new(std::path::PathBuf::from("test.zng"), text, Box::new(cfg));
         Self::parse_into(&mut zngur, &mut ctx, resolver);
+        let spec = zngur.to_zngur(&mut ctx);
         if ctx.has_errors() {
             ctx.emit_ariadne_errors();
         }
         ParseResult {
-            spec: zngur.to_zngur(),
+            spec,
             processed_files: ctx.processed_files,
         }
     }
@@ -1292,18 +1285,65 @@ impl<'a> ProcessedZngFile<'a> {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct Import(pub std::path::PathBuf);
+struct Import(pub std::path::PathBuf);
+
+struct TemplateDef {
+    ty: ZngurType,
+    filename: String,
+    span: Span,
+}
 
 #[derive(Default)]
 struct ZngurSpecBuilder {
     spec: ZngurSpec,
-    templates: Vec<ZngurType>,
+    templates: Vec<TemplateDef>,
     imports: Vec<Import>,
 }
 
 impl ZngurSpecBuilder {
-    fn to_zngur(self) -> ZngurSpec {
-        todo!()
+    fn to_zngur(self, ctx: &mut ParseContext) -> ZngurSpec {
+        let ZngurSpecBuilder {
+            mut spec,
+            templates,
+            imports: _,
+        } = self;
+        let defined_types = spec.types.iter().map(|ty| ty.ty.clone()).collect();
+        for ty in &mut spec.types {
+            for template in &templates {
+                if let Some(template_match) =
+                    try_match_template(&ty.ty, &template.ty, &defined_types)
+                {
+                    if let Err(e) = template_match.merge(ty) {
+                        let MergeFailure::Conflict(e) = e;
+                        ctx.add_report(
+                            Report::build(ReportKind::Error, &template.filename, 0)
+                                .with_message(format!(
+                                    "Failed to apply template {} to type {}: {}",
+                                    template.ty.ty, ty.ty, e
+                                ))
+                                .with_label(
+                                    Label::new((
+                                        template.filename.clone(),
+                                        template.span.start..template.span.end,
+                                    ))
+                                    .with_message("Template defined here")
+                                    .with_color(Color::Blue),
+                                )
+                                .finish(),
+                        );
+                    }
+                }
+            }
+            if !ty.wellknown_traits.iter().any(|wkt| {
+                matches!(
+                    wkt,
+                    ZngurWellknownTrait::Copy | ZngurWellknownTrait::Unsized
+                )
+            }) {
+                ty.wellknown_traits.push(ZngurWellknownTrait::Drop);
+            }
+        }
+        spec
     }
 }
 
@@ -1900,8 +1940,7 @@ fn inner_type_item<'a>()
 
 fn type_item<'a>() -> impl Parser<'a, ParserInput<'a>, ParsedItem<'a>, ZngParserExtra<'a>> + Clone {
     just(Token::KwType)
-        .ignore_then(spanned(rust_type()))
-        .then(
+        .ignore_then(
             (select! { Token::Ident(c) => c })
                 .map(ParsedTypeVar)
                 .separated_by(just(Token::Comma))
@@ -1909,15 +1948,23 @@ fn type_item<'a>() -> impl Parser<'a, ParserInput<'a>, ParsedItem<'a>, ZngParser
                 .allow_trailing()
                 .collect()
                 .delimited_by(just(Token::AngleOpen), just(Token::AngleClose))
+                .try_map_with(|vars, e: &mut MapExtra<_, ZngParserExtra>| {
+                    if !e.state().unstable_features.template_types {
+                        Err(Rich::custom(e.span(), "Template types are unstable. Enable them by using `#unstable(template_types)` at the top of the file."))
+                    } else {
+                        Ok(vars)
+                    }
+                })
                 .or_not(),
         )
+        .then(spanned(rust_type()))
         .then(
             spanned(inner_type_item())
                 .repeated()
                 .collect::<Vec<_>>()
                 .delimited_by(just(Token::BraceOpen), just(Token::BraceClose)),
         )
-        .map(|((ty, type_vars), items)| ParsedItem::Type {
+        .map(|((type_vars, ty), items)| ParsedItem::Type {
             ty,
             items,
             type_vars,
@@ -2016,6 +2063,11 @@ fn unstable_feature<'a>()
                     let ctx: &mut extra::SimpleState<ZngParserState> = e.state();
                     ctx.unstable_features.cfg_if = true;
                     Ok(ParsedItem::UnstableFeature("cfg_if"))
+                }
+                "template_types" => {
+                    let ctx: &mut extra::SimpleState<ZngParserState> = e.state();
+                    ctx.unstable_features.template_types = true;
+                    Ok(ParsedItem::UnstableFeature("template_types"))
                 }
                 _ => Err(Rich::custom(
                     e.span(),

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -1311,12 +1311,11 @@ impl ZngurSpecBuilder {
             imports: _,
             mut ty_to_locations,
         } = self;
-        let defined_types = spec.types.iter().map(|ty| ty.ty.clone()).collect();
         for ty in &mut spec.types {
             let mut template_locations = Vec::new();
             for template in &templates {
                 if let Some(template_match) =
-                    try_match_template(&ty.ty, &template.ty, &defined_types)
+                    try_match_template(&ty.ty, &template.ty)
                 {
                     let location = (
                         template.filename.clone(),

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -1340,9 +1340,6 @@ impl ZngurSpecBuilder {
             }) {
                 ty.wellknown_traits.push(ZngurWellknownTrait::Drop);
             }
-            if ty.layout.is_none() {
-                ctx.add_report(Report::build(kind, src_id, offset));
-            }
         }
         spec
     }

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -35,6 +35,7 @@ mod tests;
 
 pub mod cfg;
 mod conditional;
+mod template_types;
 
 use crate::{
     cfg::{CfgConditional, RustCfgProvider},

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -462,7 +462,9 @@ impl ProcessedItem<'_> {
                 }
             }
             ProcessedItem::ModuleImport { path, span: _ } => {
-                r.spec.imported_modules.push(ModuleImport { path: path.clone() });
+                r.spec
+                    .imported_modules
+                    .push(ModuleImport { path: path.clone() });
             }
             ProcessedItem::Type {
                 ty,
@@ -975,7 +977,6 @@ impl<'a, 'b> ParseContext<'a, 'b> {
         // Always cache the source in case errors come up in post-processing
         self.source_cache.insert(other.path, other.text.to_string());
         self.source_cache.extend(other.source_cache);
-
     }
 
     fn has_errors(&self) -> bool {
@@ -1350,12 +1351,11 @@ impl ZngurSpecBuilder {
                 ty.wellknown_traits.push(ZngurWellknownTrait::Drop);
             }
             if ty.layout.is_none() {
-                let mut report = Report::build(ReportKind::Error, "", 0)
-                    .with_message(format!(
-                        "No layout policy found for type {}. \
+                let mut report = Report::build(ReportKind::Error, "", 0).with_message(format!(
+                    "No layout policy found for type {}. \
     Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.",
-                        ty.ty
-                    ));
+                    ty.ty
+                ));
                 for location in ty_to_locations.remove(&ty.ty).unwrap_or_default() {
                     report = report.with_label(
                         Label::new(location)

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -108,7 +108,7 @@ fn substitute_vars<'a>(
         vec.iter().map(|ty| substitute_type(ty, mapping)).collect()
     }
 
-    fn subsititue_generics<'a>(
+    fn substitute_generics<'a>(
         path_and_generics: &'a RustPathAndGenerics,
         mapping: &HashMap<&TypeVar, &RustType>,
     ) -> Result<RustPathAndGenerics, &'a TypeVar> {
@@ -134,7 +134,7 @@ fn substitute_vars<'a>(
     ) -> Result<RustTrait, &'a TypeVar> {
         let result = match rust_trait {
             RustTrait::Normal(path_and_generics) => {
-                RustTrait::Normal(subsititue_generics(path_and_generics, mapping)?)
+                RustTrait::Normal(substitute_generics(path_and_generics, mapping)?)
             }
             RustTrait::Fn {
                 name,
@@ -172,7 +172,7 @@ fn substitute_vars<'a>(
             }
             RustType::Tuple(tys) => RustType::Tuple(substitute_vec(tys, mapping)?),
             RustType::Adt(path_and_generics) => {
-                RustType::Adt(subsititue_generics(path_and_generics, mapping)?)
+                RustType::Adt(substitute_generics(path_and_generics, mapping)?)
             }
         };
         Ok(ty)

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -1,0 +1,327 @@
+use std::collections::{HashMap, HashSet};
+
+use zngur_def::{
+    Merge, RustPathAndGenerics, RustTrait, RustType, TypeVar, ZngurConstructor, ZngurField,
+    ZngurMethod, ZngurMethodDetails, ZngurType,
+};
+
+fn matches_template<'a, 'b>(
+    ty: &'a RustType,
+    generic: &'b RustType,
+    mapping: &mut HashMap<&'b TypeVar, &'a RustType>,
+) -> bool {
+    fn match_lists<'a, 'b>(
+        v1: &'a [RustType],
+        v2: &'b [RustType],
+        mapping: &mut HashMap<&'b TypeVar, &'a RustType>,
+    ) -> bool {
+        v1.len() == v2.len() && match_iters(v1, v2, mapping)
+    }
+
+    fn match_iters<'a, 'b>(
+        i1: impl IntoIterator<Item = &'a RustType>,
+        i2: impl IntoIterator<Item = &'b RustType>,
+        mapping: &mut HashMap<&'b TypeVar, &'a RustType>,
+    ) -> bool {
+        i1.into_iter()
+            .zip(i2)
+            .all(|(ty1, ty2)| matches_template(ty1, ty2, mapping))
+    }
+
+    fn match_generics<'a, 'b>(
+        t1: &'a RustPathAndGenerics,
+        t2: &'b RustPathAndGenerics,
+        mapping: &mut HashMap<&'b TypeVar, &'a RustType>,
+    ) -> bool {
+        // For now named generics must be in the same order
+        t1.path == t2.path
+            && match_lists(&t1.generics, &t2.generics, mapping)
+            && t1.named_generics.len() == t2.named_generics.len()
+            && t1
+                .named_generics
+                .iter()
+                .zip(t2.named_generics.iter())
+                .all(|((n1, t1), (n2, t2))| n1 == n2 && matches_template(t1, t2, mapping))
+    }
+
+    fn match_trait<'a, 'b>(
+        t1: &'a RustTrait,
+        t2: &'b RustTrait,
+        mapping: &mut HashMap<&'b TypeVar, &'a RustType>,
+    ) -> bool {
+        match (t1, t2) {
+            (RustTrait::Normal(t1), RustTrait::Normal(t2)) => match_generics(t1, t2, mapping),
+            (
+                RustTrait::Fn {
+                    name: n1,
+                    inputs: i1,
+                    output: o1,
+                },
+                RustTrait::Fn {
+                    name: n2,
+                    inputs: i2,
+                    output: o2,
+                },
+            ) => n1 == n2 && match_lists(i1, i2, mapping) && matches_template(o1, o2, mapping),
+            (_, _) => false,
+        }
+    }
+
+    match (ty, generic) {
+        (ty, RustType::TypeVar(v)) => mapping
+            .insert(v, ty)
+            .map(|prev_binding| prev_binding == ty)
+            .unwrap_or(true),
+        (RustType::Primitive(p1), RustType::Primitive(p2)) => p1 == p2,
+        (RustType::Ref(m1, t1), RustType::Ref(m2, t2))
+        | (RustType::Raw(m1, t1), RustType::Raw(m2, t2)) => {
+            m1 == m2 && matches_template(t1, t2, mapping)
+        }
+        (RustType::Boxed(t1), RustType::Boxed(t2)) | (RustType::Slice(t1), RustType::Slice(t2)) => {
+            matches_template(t1, t2, mapping)
+        }
+        (RustType::Dyn(t1, b1), RustType::Dyn(t2, b2))
+        | (RustType::Impl(t1, b1), RustType::Impl(t2, b2)) => {
+            (b1 == b2) && match_trait(t1, t2, mapping)
+        }
+        (RustType::Tuple(tys1), RustType::Tuple(tys2)) => match_lists(tys1, tys2, mapping),
+        (RustType::Adt(adt1), RustType::Adt(adt2)) => match_generics(adt1, adt2, mapping),
+        (_, _) => false,
+    }
+}
+
+// Unfortunately we won't catch all unbound var errors because an undefiend type might appear first
+enum SubstitutionError<'a> {
+    UnboundVar(&'a TypeVar),
+    UndefinedType,
+}
+
+fn substitute_vars<'a>(
+    ty: &'a RustType,
+    mapping: &HashMap<&TypeVar, &RustType>,
+    defined_types: &HashSet<RustType>,
+) -> Result<RustType, SubstitutionError<'a>> {
+    fn substitute_vec<'a>(
+        vec: &'a Vec<RustType>,
+        mapping: &HashMap<&TypeVar, &RustType>,
+    ) -> Result<Vec<RustType>, &'a TypeVar> {
+        vec.iter().map(|ty| substitute_type(ty, mapping)).collect()
+    }
+
+    fn subsititue_generics<'a>(
+        path_and_generics: &'a RustPathAndGenerics,
+        mapping: &HashMap<&TypeVar, &RustType>,
+    ) -> Result<RustPathAndGenerics, &'a TypeVar> {
+        let RustPathAndGenerics {
+            path,
+            generics,
+            named_generics,
+        } = path_and_generics;
+        let result = RustPathAndGenerics {
+            path: path.to_owned(),
+            generics: substitute_vec(generics, mapping)?,
+            named_generics: named_generics
+                .iter()
+                .map(|(name, ty)| substitute_type(ty, mapping).map(|ty| (name.to_owned(), ty)))
+                .collect::<Result<_, _>>()?,
+        };
+        Ok(result)
+    }
+
+    fn substitute_trait<'a>(
+        rust_trait: &'a RustTrait,
+        mapping: &HashMap<&TypeVar, &RustType>,
+    ) -> Result<RustTrait, &'a TypeVar> {
+        let result = match rust_trait {
+            RustTrait::Normal(path_and_generics) => {
+                RustTrait::Normal(subsititue_generics(path_and_generics, mapping)?)
+            }
+            RustTrait::Fn {
+                name,
+                inputs,
+                output,
+            } => RustTrait::Fn {
+                name: name.to_owned(),
+                inputs: substitute_vec(inputs, mapping)?,
+                output: Box::new(substitute_type(output, mapping)?),
+            },
+        };
+        Ok(result)
+    }
+
+    fn substitute_type<'a>(
+        ty: &'a RustType,
+        mapping: &HashMap<&TypeVar, &RustType>,
+    ) -> Result<RustType, &'a TypeVar> {
+        let ty = match ty {
+            RustType::TypeVar(v) => match mapping.get(v) {
+                Some(ty) => (*ty).to_owned(),
+                None => return Err(v),
+            },
+            p @ RustType::Primitive(_) => p.to_owned(),
+            RustType::Ref(m, t) => RustType::Ref(*m, Box::new(substitute_type(t, mapping)?)),
+            RustType::Raw(m, t) => RustType::Raw(*m, Box::new(substitute_type(t, mapping)?)),
+            RustType::Boxed(t) => RustType::Boxed(Box::new(substitute_type(t, mapping)?)),
+            RustType::Slice(t) => RustType::Slice(Box::new(substitute_type(t, mapping)?)),
+            // TODO: Recurse
+            RustType::Dyn(rust_trait, bounds) => {
+                RustType::Dyn(substitute_trait(rust_trait, mapping)?, bounds.to_owned())
+            }
+            RustType::Impl(rust_trait, bounds) => {
+                RustType::Impl(substitute_trait(rust_trait, mapping)?, bounds.to_owned())
+            }
+            RustType::Tuple(tys) => RustType::Tuple(substitute_vec(tys, mapping)?),
+            RustType::Adt(path_and_generics) => {
+                RustType::Adt(subsititue_generics(path_and_generics, mapping)?)
+            }
+        };
+        Ok(ty)
+    }
+
+    match substitute_type(ty, mapping) {
+        Ok(ty) => {
+            if defined_types.contains(&ty) {
+                Ok(ty)
+            } else {
+                Err(SubstitutionError::UndefinedType)
+            }
+        }
+        Err(var) => Err(SubstitutionError::UnboundVar(var)),
+    }
+}
+
+fn substitute_method_vars<'a>(
+    m: &'a ZngurMethodDetails,
+    mapping: &HashMap<&TypeVar, &RustType>,
+    defined_types: &HashSet<RustType>,
+) -> Result<ZngurMethodDetails, SubstitutionError<'a>> {
+    let ZngurMethodDetails {
+        data:
+            ZngurMethod {
+                name,
+                generics,
+                receiver,
+                inputs,
+                output,
+            },
+        use_path,
+        deref,
+    } = m;
+    Ok(ZngurMethodDetails {
+        data: ZngurMethod {
+            name: name.to_owned(),
+            generics: generics
+                .iter()
+                .map(|ty| substitute_vars(ty, mapping, defined_types))
+                .collect::<Result<_, _>>()?,
+            receiver: *receiver,
+            inputs: inputs
+                .iter()
+                .map(|ty| substitute_vars(ty, mapping, defined_types))
+                .collect::<Result<_, _>>()?,
+            output: substitute_vars(output, mapping, defined_types)?,
+        },
+        use_path: use_path.to_owned(),
+        deref: deref
+            .as_ref()
+            .map(|(ty, mutability)| {
+                Ok((substitute_vars(&ty, mapping, defined_types)?, *mutability))
+            })
+            .transpose()?,
+    })
+}
+
+fn template_to_type(
+    ty: &RustType,
+    template: &ZngurType,
+    defined_types: &HashSet<RustType>,
+) -> Option<ZngurType> {
+    fn validate(defined_types: &HashSet<RustType>) -> impl Fn(&RustType) -> bool {
+        |ty| {
+            let ty = match ty {
+                RustType::Raw(_, ty) | RustType::Ref(_, ty) => ty,
+                ty => ty,
+            };
+            match ty {
+                RustType::Primitive(_) => true,
+                ty => defined_types.contains(ty),
+            }
+        }
+    }
+    let mut mapping = HashMap::new();
+    if !matches_template(ty, &template.ty, &mut mapping) {
+        return None;
+    }
+    let ZngurType {
+        ty: template_ty,
+        layout,
+        wellknown_traits,
+        methods,
+        constructors,
+        fields,
+        cpp_ref,
+        cpp_value,
+    } = template;
+    Some(ZngurType {
+        ty: ty.to_owned(),
+        layout: *layout,
+        wellknown_traits: wellknown_traits.to_owned(),
+        methods: methods
+            .iter()
+            .filter_map(
+                |method| match substitute_method_vars(method, &mapping, &validate(defined_types)) {
+                    Ok(m) => Some(m),
+                    Err(SubstitutionError::UndefinedType) => None,
+                    Err(SubstitutionError::UnboundVar(var)) => panic!(
+                        "Failed to substitute type variable {} in method {} in template {:?} for type {}",
+                        var.0, method.data.name, template.ty, ty
+                    ),
+                },
+            )
+            .collect(),
+        constructors: constructors.iter().filter_map(|constructor|
+            match constructor.inputs.iter().map(|(name, ty)| substitute_vars(ty, &mapping, &validate(defined_types)).map(|ty| (name.to_owned(), ty))).collect() {
+                Ok(inputs) => Some(ZngurConstructor {
+                    name: constructor.name.to_owned(),
+                    inputs
+                }),
+                Err(SubstitutionError::UndefinedType) => None,
+                Err(SubstitutionError::UnboundVar(var)) => panic!(
+                        "Failed to substitute type variable {} in contsructor {:?} in template {:?} for type {}",
+                        var.0, constructor.name, template.ty, ty
+                    ),
+            }
+        ).collect(),
+        fields: fields.iter().filter_map(|field| {
+            match substitute_vars(&field.ty, &mapping, &validate(defined_types)) {
+                Ok(ty) => Some(ZngurField {
+                    name: field.name.to_owned(),
+                    ty,
+                    offset: field.offset
+                }),
+                Err(SubstitutionError::UndefinedType) => None,
+                Err(SubstitutionError::UnboundVar(var)) => panic!(
+                        "Failed to substitute type variable {} in field {} in template {:?} for type {}",
+                        var.0, field.name, template.ty, ty
+                    ),
+            }
+        }
+        ).collect(),
+        cpp_value: cpp_value.to_owned(),
+        cpp_ref: cpp_ref.to_owned(),
+    })
+}
+
+// Represents a ZngurType created from a template type
+pub struct TemplateMatch(ZngurType);
+
+impl Merge<ZngurType> for TemplateMatch {
+    fn merge(self, into: &mut ZngurType) -> zngur_def::MergeResult {
+        let TemplateMatch(mut ty) = self;
+        // The concrete type's layout should override the template's layout without causing a conflict
+        if into.layout.is_some() {
+            ty.layout = None;
+        }
+        ty.merge(into)
+    }
+}

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -213,18 +213,13 @@ fn substitute_method_vars<'a>(
         },
         use_path: use_path.clone(),
         deref: match deref {
-            Some((ty, mutability)) => {
-                Some((substitute_vars(&ty, mapping)?, *mutability))
-            }
+            Some((ty, mutability)) => Some((substitute_vars(&ty, mapping)?, *mutability)),
             None => None,
         },
     })
 }
 
-pub fn try_match_template(
-    ty: &RustType,
-    template: &ZngurType,
-) -> Option<TemplateMatch> {
+pub fn try_match_template(ty: &RustType, template: &ZngurType) -> Option<TemplateMatch> {
     let mut mapping = HashMap::new();
     if !matches_template(ty, &template.ty, &mut mapping) {
         return None;
@@ -240,25 +235,20 @@ pub fn try_match_template(
         cpp_value,
         cpp_stack_owned,
     } = template;
-    debug_assert_eq!(
-        substitute_vars(template_ty, &mapping).unwrap(),
-        *ty
-    );
+    debug_assert_eq!(substitute_vars(template_ty, &mapping).unwrap(), *ty);
     let new_ty = ZngurType {
         ty: ty.clone(),
         layout: *layout,
         wellknown_traits: wellknown_traits.clone(),
         methods: methods
             .iter()
-            .filter_map(
-                |method| match substitute_method_vars(method, &mapping) {
-                    Ok(m) => Some(m),
-                    Err(SubstitutionError::UnboundVar(var)) => unreachable!(
-                        "Unbound type variable {} in method {} in template {} for type {}",
-                        var.0, method.data.name, template.ty, ty
-                    ),
-                },
-            )
+            .filter_map(|method| match substitute_method_vars(method, &mapping) {
+                Ok(m) => Some(m),
+                Err(SubstitutionError::UnboundVar(var)) => unreachable!(
+                    "Unbound type variable {} in method {} in template {} for type {}",
+                    var.0, method.data.name, template.ty, ty
+                ),
+            })
             .collect(),
         constructors: constructors
             .iter()
@@ -266,9 +256,7 @@ pub fn try_match_template(
                 match constructor
                     .inputs
                     .iter()
-                    .map(|(name, ty)| {
-                        substitute_vars(ty, &mapping).map(|ty| (name.clone(), ty))
-                    })
+                    .map(|(name, ty)| substitute_vars(ty, &mapping).map(|ty| (name.clone(), ty)))
                     .collect()
                 {
                     Ok(inputs) => Some(ZngurConstructor {
@@ -284,19 +272,17 @@ pub fn try_match_template(
             .collect(),
         fields: fields
             .iter()
-            .filter_map(
-                |field| match substitute_vars(&field.ty, &mapping) {
-                    Ok(ty) => Some(ZngurField {
-                        name: field.name.clone(),
-                        ty,
-                        offset: field.offset,
-                    }),
-                    Err(SubstitutionError::UnboundVar(var)) => unreachable!(
-                        "Unbound type variable {} in field {} in template {} for type {}",
-                        var.0, field.name, template.ty, ty
-                    ),
-                },
-            )
+            .filter_map(|field| match substitute_vars(&field.ty, &mapping) {
+                Ok(ty) => Some(ZngurField {
+                    name: field.name.clone(),
+                    ty,
+                    offset: field.offset,
+                }),
+                Err(SubstitutionError::UnboundVar(var)) => unreachable!(
+                    "Unbound type variable {} in field {} in template {} for type {}",
+                    var.0, field.name, template.ty, ty
+                ),
+            })
             .collect(),
         cpp_value: cpp_value.clone(),
         cpp_ref: cpp_ref.clone(),

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use zngur_def::{
     Merge, RustPathAndGenerics, RustTrait, RustType, TypeVar, ZngurConstructor, ZngurField,
@@ -93,13 +93,11 @@ fn matches_template<'a, 'b>(
 #[derive(Debug)]
 enum SubstitutionError<'a> {
     UnboundVar(&'a TypeVar),
-    UndefinedType,
 }
 
 fn substitute_vars<'a>(
     ty: &'a RustType,
     mapping: &HashMap<&TypeVar, &RustType>,
-    defined_types: &HashSet<RustType>,
 ) -> Result<RustType, SubstitutionError<'a>> {
     fn substitute_vec<'a>(
         vec: &'a Vec<RustType>,
@@ -178,33 +176,12 @@ fn substitute_vars<'a>(
         Ok(ty)
     }
 
-    match substitute_type(ty, mapping) {
-        Ok(ty) => {
-            let mut curr_ty = &ty;
-            let type_defined = loop {
-                match curr_ty {
-                    // Primitives and Unit are automatically defined
-                    RustType::Primitive(_) => break true,
-                    RustType::Tuple(t) if t.is_empty() => break true,
-                    // Ref and raw types are automatically defined
-                    RustType::Ref(_, inner) | RustType::Raw(_, inner) => curr_ty = inner,
-                    ty => break defined_types.contains(&ty),
-                }
-            };
-            if type_defined {
-                Ok(ty)
-            } else {
-                Err(SubstitutionError::UndefinedType)
-            }
-        }
-        Err(var) => Err(SubstitutionError::UnboundVar(var)),
-    }
+    substitute_type(ty, mapping).map_err(SubstitutionError::UnboundVar)
 }
 
 fn substitute_method_vars<'a>(
     m: &'a ZngurMethodDetails,
     mapping: &HashMap<&TypeVar, &RustType>,
-    defined_types: &HashSet<RustType>,
 ) -> Result<ZngurMethodDetails, SubstitutionError<'a>> {
     let ZngurMethodDetails {
         data:
@@ -224,20 +201,20 @@ fn substitute_method_vars<'a>(
             name: name.clone(),
             generics: generics
                 .iter()
-                .map(|ty| substitute_vars(ty, mapping, defined_types))
+                .map(|ty| substitute_vars(ty, mapping))
                 .collect::<Result<_, _>>()?,
             receiver: *receiver,
             inputs: inputs
                 .iter()
-                .map(|ty| substitute_vars(ty, mapping, defined_types))
+                .map(|ty| substitute_vars(ty, mapping))
                 .collect::<Result<_, _>>()?,
-            output: substitute_vars(output, mapping, defined_types)?,
+            output: substitute_vars(output, mapping)?,
             is_safe: *is_safe,
         },
         use_path: use_path.clone(),
         deref: match deref {
             Some((ty, mutability)) => {
-                Some((substitute_vars(&ty, mapping, defined_types)?, *mutability))
+                Some((substitute_vars(&ty, mapping)?, *mutability))
             }
             None => None,
         },
@@ -247,7 +224,6 @@ fn substitute_method_vars<'a>(
 pub fn try_match_template(
     ty: &RustType,
     template: &ZngurType,
-    defined_types: &HashSet<RustType>,
 ) -> Option<TemplateMatch> {
     let mut mapping = HashMap::new();
     if !matches_template(ty, &template.ty, &mut mapping) {
@@ -265,7 +241,7 @@ pub fn try_match_template(
         cpp_stack_owned,
     } = template;
     debug_assert_eq!(
-        substitute_vars(template_ty, &mapping, defined_types).unwrap(),
+        substitute_vars(template_ty, &mapping).unwrap(),
         *ty
     );
     let new_ty = ZngurType {
@@ -275,9 +251,8 @@ pub fn try_match_template(
         methods: methods
             .iter()
             .filter_map(
-                |method| match substitute_method_vars(method, &mapping, defined_types) {
+                |method| match substitute_method_vars(method, &mapping) {
                     Ok(m) => Some(m),
-                    Err(SubstitutionError::UndefinedType) => None,
                     Err(SubstitutionError::UnboundVar(var)) => unreachable!(
                         "Unbound type variable {} in method {} in template {} for type {}",
                         var.0, method.data.name, template.ty, ty
@@ -292,7 +267,7 @@ pub fn try_match_template(
                     .inputs
                     .iter()
                     .map(|(name, ty)| {
-                        substitute_vars(ty, &mapping, defined_types).map(|ty| (name.clone(), ty))
+                        substitute_vars(ty, &mapping).map(|ty| (name.clone(), ty))
                     })
                     .collect()
                 {
@@ -300,7 +275,6 @@ pub fn try_match_template(
                         name: constructor.name.clone(),
                         inputs,
                     }),
-                    Err(SubstitutionError::UndefinedType) => None,
                     Err(SubstitutionError::UnboundVar(var)) => unreachable!(
                         "Unbound type variable {} in constructor {:?} in template {} for type {}",
                         var.0, constructor.name, template.ty, ty
@@ -311,13 +285,12 @@ pub fn try_match_template(
         fields: fields
             .iter()
             .filter_map(
-                |field| match substitute_vars(&field.ty, &mapping, defined_types) {
+                |field| match substitute_vars(&field.ty, &mapping) {
                     Ok(ty) => Some(ZngurField {
                         name: field.name.clone(),
                         ty,
                         offset: field.offset,
                     }),
-                    Err(SubstitutionError::UndefinedType) => None,
                     Err(SubstitutionError::UnboundVar(var)) => unreachable!(
                         "Unbound type variable {} in field {} in template {} for type {}",
                         var.0, field.name, template.ty, ty

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -214,6 +214,7 @@ fn substitute_method_vars<'a>(
                 receiver,
                 inputs,
                 output,
+                is_safe,
             },
         use_path,
         deref,
@@ -231,6 +232,7 @@ fn substitute_method_vars<'a>(
                 .map(|ty| substitute_vars(ty, mapping, defined_types))
                 .collect::<Result<_, _>>()?,
             output: substitute_vars(output, mapping, defined_types)?,
+            is_safe: *is_safe,
         },
         use_path: use_path.clone(),
         deref: match deref {
@@ -260,6 +262,7 @@ pub fn try_match_template(
         fields,
         cpp_ref,
         cpp_value,
+        cpp_stack_owned,
     } = template;
     debug_assert_eq!(
         substitute_vars(template_ty, &mapping, defined_types).unwrap(),
@@ -324,6 +327,7 @@ pub fn try_match_template(
             .collect(),
         cpp_value: cpp_value.clone(),
         cpp_ref: cpp_ref.clone(),
+        cpp_stack_owned: cpp_stack_owned.clone(),
     };
     Some(TemplateMatch(new_ty))
 }

--- a/zngur-parser/src/tests.rs
+++ b/zngur-parser/src/tests.rs
@@ -541,8 +541,8 @@ type Main {
     assert!(file_names.contains(&"c.zng"));
 }
 
-fn assert_layout(wanted_size: usize, wanted_align: usize, layout: &LayoutPolicy) {
-    if !matches!(layout, LayoutPolicy::StackAllocated { size, align } if *size == wanted_size && *align == wanted_align)
+fn assert_layout(wanted_size: usize, wanted_align: usize, layout: &Option<LayoutPolicy>) {
+    if !matches!(layout, Some(LayoutPolicy::StackAllocated { size, align }) if *size == wanted_size && *align == wanted_align)
     {
         panic!(
             "no match: StackAllocated {{ size: {wanted_size}, align: {wanted_align} }} != {:?} ",

--- a/zngur-parser/src/tests.rs
+++ b/zngur-parser/src/tests.rs
@@ -323,12 +323,12 @@ fn import_has_conflict() {
     }
 "#,
         expect![[r#"
-            Error: Duplicate layout policy found
+            Error: Conflicting layout policy found
                ╭─[a.zng:2:12]
                │
              2 │       type A {
                │            ┬  
-               │            ╰── Duplicate layout policy found
+               │            ╰── Conflicting layout policy found
             ───╯
         "#]],
         &resolver,

--- a/zngur-parser/src/tests.rs
+++ b/zngur-parser/src/tests.rs
@@ -336,6 +336,81 @@ fn import_has_conflict() {
 }
 
 #[test]
+fn missing_layout_across_files() {
+    // Test that a type defined in multiple places without a layout produces a reasonable error message.
+    let resolver = MockFilesystem::new(vec![(
+        "./a.zng",
+        r#"
+      type A {
+      }
+    "#,
+    )]);
+
+    check_import_fail(
+        r#"
+    merge "./a.zng";
+    type A {}
+"#,
+        expect![[r#"
+            Error: No layout policy found for type ::A. Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.
+               ╭─[test.zng:3:10]
+               │
+             3 │     type A {}
+               │          ┬  
+               │          ╰── Type defined here
+               │
+               ├─[a.zng:2:12]
+               │
+             2 │       type A {
+               │            ┬  
+               │            ╰── Type defined here
+            ───╯
+        "#]],
+        &resolver,
+    );
+}
+
+#[test]
+fn missing_layout_across_files_with_template() {
+    // Test that a type defined in multiple places without a layout produces a reasonable error message.
+    let resolver = MockFilesystem::new(vec![(
+        "./a.zng",
+        r#"
+      type A<B> {
+      }
+    "#,
+    )]);
+
+    check_import_fail(
+        r#"
+    #unstable(template_types)
+    merge "./a.zng";
+    type<T> A<T> {}
+    type A<B> {}
+"#,
+        expect![[r#"
+            Error: No layout policy found for type ::A::<::B>. Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`.
+               ╭─[test.zng:5:10]
+               │
+             4 │     type<T> A<T> {}
+               │             ──┬─  
+               │               ╰─── Matching template defined here
+             5 │     type A<B> {}
+               │          ──┬─  
+               │            ╰─── Type defined here
+               │
+               ├─[a.zng:2:12]
+               │
+             2 │       type A<B> {
+               │            ──┬─  
+               │              ╰─── Type defined here
+            ───╯
+        "#]],
+        &resolver,
+    );
+}
+
+#[test]
 fn import_not_found() {
     let resolver = MockFilesystem::new(vec![] as Vec<(&str, &str)>);
     check_import_fail(


### PR DESCRIPTION
Still a little code cleanup to do, but want to get review on overall design.

Adds the ability to create templated type definitions to `.zng` files, such as the following
```
type<T> ::std::vec::Vec<T> {
    #layout(size = 24, align = 8);
    fn new() -> :std::vec::Vec<T>;
    fn push(&mut self, T);
    fn len(&self) -> usize;

    fn get(&self, usize) -> :std::option::Option<&T> deref [T];
}
```
Now, when a definition like the following is added, the method, trait, and layout information is automatically copied from the template.
```
type ::std::vec::Vec<crate::MyType> {}
```
As shown, this allows for very compact definitions of common generic types.

With the current design, you could not call `Vec<MyType>::get(...)` because `[MyType]` and `Option<&MyType>` are not defined. Template types do not add any new type definitions nor do they force you to add definitions that you aren't going to use. See examples/template_types/main.zng for more details.

Definitely open to feedback on the design. My team has been using a system like this for a while and have found it very convenient.
