### PR TITLE
Add a C++/Rust inheritance layer example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,10 @@ name = "example-conditional"
 version = "0.9.0"
 
 [[package]]
+name = "example-cpp-inheritance"
+version = "0.9.0"
+
+[[package]]
 name = "example-cxx_demo"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,15 @@ name = "example-simple-import"
 version = "0.9.0"
 
 [[package]]
+name = "example-stack-owned"
+version = "0.9.0"
+dependencies = [
+ "build-rs",
+ "cc",
+ "zngur",
+]
+
+[[package]]
 name = "example-tutorial"
 version = "0.9.0"
 

--- a/examples/cpp_inheritance/Cargo.toml
+++ b/examples/cpp_inheritance/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example-cpp-inheritance"
+version = "0.9.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]

--- a/examples/cpp_inheritance/Makefile
+++ b/examples/cpp_inheritance/Makefile
@@ -1,0 +1,21 @@
+a.out: generated.o impls.o src/generated.rs src/main.rs
+	cargo b --release
+	cp ../../target/release/example-cpp-inheritance a.out
+
+impls.o: task.h impls.h cpp_rust_inheritance.h generated.h impls.cpp
+	${CXX} -std=c++11 -c -Werror -I. impls.cpp
+
+generated.o: task.h generated.h generated.cpp impls.h
+	${CXX} -std=c++11 -c -Werror -I. generated.cpp
+
+generated.h src/generated.rs generated.cpp: main.zng zngur.h
+	cd ../../zngur-cli && cargo run g ../examples/cpp_inheritance/main.zng --crate-name "crate"
+
+zngur.h:
+	cd ../../zngur-cli && cargo run h ../examples/cpp_inheritance/zngur.h
+	
+
+.PHONY: clean
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt *.o

--- a/examples/cpp_inheritance/build.rs
+++ b/examples/cpp_inheritance/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let dir = std::env::current_dir().unwrap();
+    println!("cargo:rustc-link-arg={}/generated.o", dir.display());
+    println!("cargo:rustc-link-arg={}/impls.o", dir.display());
+    println!("cargo:rustc-link-lib=stdc++");
+}

--- a/examples/cpp_inheritance/cpp_rust_inheritance.h
+++ b/examples/cpp_inheritance/cpp_rust_inheritance.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "zngur.h"
+
+namespace rust {
+template <typename CppBase, typename RustDerived> class RustInherit {
+public:
+  static RawMut<RustDerived> get_rust(CppBase *base);
+  static CppBase *get_base(RawMut<RustDerived> derived);
+
+private:
+  static void *AlignedTo(void *unaligned_addr, size_t alignment);
+  static size_t DerivedAlign();
+  static size_t FullAlign();
+};
+
+template <typename T> RawMut<T> as_rust_ptr_mut(T *t) {
+  return *reinterpret_cast<RawMut<T> *>(&t);
+}
+
+template <typename T> T *from_rust_ptr(RawMut<T> t) {
+  return *reinterpret_cast<T **>(&t);
+}
+
+template <typename T> RefMut<T> to_rust_ref_mut(RawMut<T> t) {
+  RefMut<T> r;
+  *reinterpret_cast<RawMut<T> *>(&r) = t;
+  return r;
+}
+
+template <typename CppBase, typename RustDerived>
+RawMut<RustDerived> RustInherit<CppBase, RustDerived>::get_rust(CppBase *base) {
+  return as_rust_ptr_mut<RustDerived>((RustDerived *)(AlignedTo(
+      (char *)(base) + sizeof(CppBase), DerivedAlign())));
+}
+
+template <typename CppBase, typename RustDerived>
+CppBase *
+RustInherit<CppBase, RustDerived>::get_base(RawMut<RustDerived> derived) {
+  return reinterpret_cast<CppBase *>(AlignedTo(
+      (char *)(from_rust_ptr(derived)) - sizeof(CppBase), FullAlign()));
+}
+
+template <typename CppBase, typename RustDerived>
+void *RustInherit<CppBase, RustDerived>::AlignedTo(void *unaligned_addr,
+                                                   size_t alignment) {
+  uintptr_t aligned_addr =
+      ((uintptr_t)(unaligned_addr) + alignment - 1) & ~(alignment - 1);
+  return (void *)(aligned_addr);
+}
+
+template <typename CppBase, typename RustDerived>
+size_t RustInherit<CppBase, RustDerived>::DerivedAlign() {
+  return ::rust::__zngur_internal<RustDerived>::align_of();
+}
+
+template <typename CppBase, typename RustDerived>
+size_t RustInherit<CppBase, RustDerived>::FullAlign() {
+  return std::max(alignof(CppBase), DerivedAlign());
+}
+} // namespace rust

--- a/examples/cpp_inheritance/expected_output.txt
+++ b/examples/cpp_inheritance/expected_output.txt
@@ -1,0 +1,1 @@
+Hello from Rust async!

--- a/examples/cpp_inheritance/impls.cpp
+++ b/examples/cpp_inheritance/impls.cpp
@@ -1,0 +1,37 @@
+#include "impls.h"
+#include "generated.h"
+#include "task.h"
+#include <new>
+
+namespace rust {
+
+rust::Unit
+Impl<rust::crate::CppTask>::init(rust::Ref<rust::crate::CppTask> self) {
+  new (&self.cpp()) task::CppTaskForRust();
+  return {};
+}
+
+::rust::crate::Dispatcher Impl<rust::crate::Dispatcher>::new_() {
+  auto self = ::rust::crate::Dispatcher{};
+  self.drop_flag = true;
+  return self;
+}
+
+::rust::Unit Impl<rust::crate::Dispatcher>::run_task(
+    ::rust::Ref<rust::crate::Dispatcher> self, ::rust::RefMut<rust::crate::RustTask> task) {
+  auto &d = self.cpp();
+  ::rust::RawMut<::rust::crate::RustTask> raw_mut(task);
+  ::rust::crate::RustTask* rust_ptr = ::rust::from_rust_ptr(raw_mut);
+  task::CppTaskForRust* task_ref = task::CppTaskForRust::Inheritance::get_base(::rust::as_rust_ptr_mut(rust_ptr));
+  d.run_task(task_ref);
+  return {};
+}
+
+} // namespace rust
+
+task::Poll task::CppTaskForRust::poll() {
+  ::rust::RawMut<::rust::crate::RustTask> rust_future = Inheritance::get_rust(this);
+  ::rust::RefMut<::rust::crate::RustTask> ref_mut = ::rust::to_rust_ref_mut(rust_future);
+  ::rust::core::task::Poll<::rust::Unit> result = ::rust::crate::RustTask::poll(ref_mut);
+  return result.is_ready() ? task::Poll::kReady : task::Poll::kPending;
+}

--- a/examples/cpp_inheritance/impls.h
+++ b/examples/cpp_inheritance/impls.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "task.h"
+#include "zngur.h"
+#include "cpp_rust_inheritance.h"
+
+namespace rust {
+  namespace crate {
+    class RustTask;
+  }
+}
+
+namespace task {
+class CppTaskForRust : public Task {
+public:
+  virtual Poll poll() override;
+  virtual ~CppTaskForRust() override {}
+  using Inheritance = ::rust::RustInherit<CppTaskForRust, ::rust::crate::RustTask>;
+};
+}
+
+namespace rust {
+template<>
+struct is_trivially_relocatable<task::Dispatcher> : std::true_type {};
+template<>
+struct is_trivially_relocatable<task::CppTaskForRust> : std::true_type {};
+}

--- a/examples/cpp_inheritance/main.zng
+++ b/examples/cpp_inheritance/main.zng
@@ -1,0 +1,41 @@
+#cpp_additional_includes "
+#include <impls.h>
+"
+
+type crate::CppTask {
+    #cpp_stack_owned "task::CppTaskForRust" (size = 8, align = 8);
+}
+
+type crate::Dispatcher {
+    #cpp_stack_owned "task::Dispatcher" (size = 1, align = 1);
+}
+
+type ::core::task::Poll<()> {
+    #layout(size = 1, align = 1);
+    constructor Ready(());
+    constructor Pending;
+
+    fn is_ready(&self) -> bool;
+    fn is_pending(&self) -> bool;
+}
+
+type crate::RustTask {
+    #layout(size = 16, align = 8);
+    fn poll(&mut crate::RustTask) -> core::task::Poll<()>;
+}
+
+extern "C++" {
+    impl crate::CppTask {
+        fn init(&self);
+    }
+
+    impl crate::Dispatcher {
+        fn new() -> crate::Dispatcher;
+        fn run_task(&self, &mut crate::RustTask);
+    }
+}
+
+type bool {
+    #layout(size = 1, align = 1);
+}
+

--- a/examples/cpp_inheritance/output.txt
+++ b/examples/cpp_inheritance/output.txt
@@ -1,0 +1,1 @@
+Use of uninitialized or moved Zngur Rust object with type ::rust::crate::CppTask

--- a/examples/cpp_inheritance/src/lib.rs
+++ b/examples/cpp_inheritance/src/lib.rs
@@ -1,0 +1,40 @@
+use std::mem::MaybeUninit;
+
+pub unsafe trait Cpp {}
+
+#[repr(C)]
+pub struct CppInherit<Base, T> {
+    pub base: Base,
+    pub inner: T,
+}
+
+impl<Base, T> CppInherit<Base, T> {
+    pub fn new_with<F>(inner: T, base_init: F) -> Self
+    where
+        F: FnOnce(&mut Base),
+    {
+        let mut this = CppInherit {
+            // SAFETY: The base class is just a buffer at this point and we properly initialize it below
+            base: unsafe { MaybeUninit::<Base>::uninit().assume_init() },
+            inner,
+        };
+        base_init(&mut this.base);
+        this
+    }
+
+    pub fn base(&self) -> &Base {
+        &self.base
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    pub unsafe fn inner_from_raw_mut(this: *mut Self) -> *mut T {
+        unsafe { &mut (*this).inner }
+    }
+}

--- a/examples/cpp_inheritance/src/main.rs
+++ b/examples/cpp_inheritance/src/main.rs
@@ -1,0 +1,38 @@
+#![allow(non_camel_case_types)]
+
+mod generated;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+use example_cpp_inheritance::CppInherit;
+pub use generated::cpp::CppTask;
+pub use generated::cpp::Dispatcher;
+
+pub struct RustTask<'a>(pub Pin<&'a mut dyn Future<Output = ()>>);
+
+impl<'a> RustTask<'a> {
+    pub fn poll(&mut self) -> Poll<()> {
+        let waker = unsafe { Waker::from_raw(dummy_raw_waker()) };
+        let mut cx = Context::from_waker(&waker);
+        self.0.as_mut().poll(&mut cx)
+    }
+}
+
+unsafe fn dummy_raw_waker() -> std::task::RawWaker {
+    static DUMMY_WAKER_VTABLE: std::task::RawWakerVTable =
+        std::task::RawWakerVTable::new(|_| unsafe { dummy_raw_waker() }, |_| (), |_| (), |_| ());
+    std::task::RawWaker::new(std::ptr::null(), &DUMMY_WAKER_VTABLE)
+}
+
+fn main() {
+    let mut fut = async {
+        println!("Hello from Rust async!");
+    };
+
+    let fut = RustTask(unsafe { Pin::new_unchecked(&mut fut) });
+    let mut task: CppInherit<CppTask, RustTask> = CppInherit::new_with(fut, |base: &mut CppTask| base.init());
+    let dispatcher = Dispatcher::new();
+    dispatcher.run_task(&mut task.inner);
+}

--- a/examples/cpp_inheritance/task.h
+++ b/examples/cpp_inheritance/task.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <cstdint>
+
+namespace task {
+
+enum class Poll {
+  kPending,
+  kReady,
+};
+
+class Task {
+public:
+  virtual ~Task() {}
+  virtual Poll poll() = 0;
+};
+
+class Dispatcher {
+public:
+  void run_task(Task* task) {
+    while (task->poll() == Poll::kPending) {
+    }
+  }
+};
+
+} // namespace task
+

--- a/examples/stack_owned/Cargo.toml
+++ b/examples/stack_owned/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-stack-owned"
+version = "0.9.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+
+[build-dependencies]
+cc = "1.0"
+build-rs = "0.1.2"
+zngur = { path = "../../zngur" }

--- a/examples/stack_owned/Makefile
+++ b/examples/stack_owned/Makefile
@@ -1,0 +1,7 @@
+a.out: src/main.rs build.rs main.zng impls.cpp
+	cargo build
+	cp ../../target/debug/example-stack-owned a.out
+
+.PHONY: clean
+clean:
+	rm -f a.out actual_output.txt generated.h generated.cpp src/generated.rs

--- a/examples/stack_owned/NMakefile
+++ b/examples/stack_owned/NMakefile
@@ -1,0 +1,6 @@
+a.exe: src/main.rs build.rs main.zng impls.cpp
+	cargo build
+	copy ..\..\target\debug\example-stack-owned.exe a.exe
+
+clean:
+	- del /f /q a.exe actual_output.txt generated.h generated.cpp src\generated.rs 2>nul

--- a/examples/stack_owned/build.rs
+++ b/examples/stack_owned/build.rs
@@ -1,0 +1,23 @@
+use zngur::Zngur;
+
+fn main() {
+    build::rerun_if_changed("main.zng");
+    build::rerun_if_changed("impls.cpp");
+    build::rerun_if_changed("src/");
+
+    let crate_dir = build::cargo_manifest_dir();
+
+    Zngur::from_zng_file(crate_dir.join("main.zng"))
+        .with_cpp_file(crate_dir.join("generated.cpp"))
+        .with_h_file(crate_dir.join("generated.h"))
+        .with_rs_file(crate_dir.join("./src/generated.rs"))
+        .with_crate_name("crate")
+        .with_zng_header("zngur.h")
+        .generate();
+
+    let mut my_build = cc::Build::new();
+    my_build.cpp(true).std("c++11").include(".");
+
+    my_build.file("generated.cpp").compile("zngur_generated");
+    my_build.file("impls.cpp").compile("impls_cpp");
+}

--- a/examples/stack_owned/cpp_type.h
+++ b/examples/stack_owned/cpp_type.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <iostream>
+#include <type_traits>
+#include <zngur.h>
+
+struct CppType {
+  int x;
+  int y;
+
+  CppType(int x, int y) : x(x), y(y) {
+    std::cout << "Constructed CppType " << x << " " << y << std::endl;
+  }
+  ~CppType() {
+    std::cout << "Destructed CppType " << x << " " << y << std::endl;
+  }
+};
+
+namespace rust {
+template <> struct is_trivially_relocatable<CppType> : std::true_type {};
+} // namespace rust

--- a/examples/stack_owned/expected_output.txt
+++ b/examples/stack_owned/expected_output.txt
@@ -1,0 +1,6 @@
+Hello from Rust
+Constructed CppType 10 20
+Rust got CppType
+CppType 10 20
+Rust dropping CppType
+Destructed CppType 10 20

--- a/examples/stack_owned/impls.cpp
+++ b/examples/stack_owned/impls.cpp
@@ -1,0 +1,24 @@
+#include "cpp_type.h"
+
+#include <iostream>
+
+#include "generated.h"
+
+namespace rust {
+namespace exported_functions {
+
+rust::crate::MyCppWrapper create_cpp_type(int32_t x, int32_t y) {
+  rust::crate::MyCppWrapper w;
+  new (&w.cpp()) CppType(x, y);
+  ::rust::__zngur_internal_assume_init(w);
+  return w;
+}
+
+rust::Unit print_cpp_type(rust::Ref<rust::crate::MyCppWrapper> c) {
+  const CppType &cpp = c.cpp();
+  std::cout << "CppType " << cpp.x << " " << cpp.y << std::endl;
+  return rust::Unit{};
+}
+
+} // namespace exported_functions
+} // namespace rust

--- a/examples/stack_owned/main.zng
+++ b/examples/stack_owned/main.zng
@@ -1,0 +1,12 @@
+#cpp_additional_includes "
+#include <cpp_type.h>
+"
+
+type crate::MyCppWrapper {
+    #cpp_stack_owned "::CppType" (size = 8, align = 4);
+}
+
+extern "C++" {
+    fn create_cpp_type(i32, i32) -> crate::MyCppWrapper;
+    fn print_cpp_type(&crate::MyCppWrapper);
+}

--- a/examples/stack_owned/src/main.rs
+++ b/examples/stack_owned/src/main.rs
@@ -1,0 +1,12 @@
+#[rustfmt::skip]
+mod generated;
+
+pub use generated::cpp::MyCppWrapper;
+
+fn main() {
+    println!("Hello from Rust");
+    let c = generated::create_cpp_type(10, 20);
+    println!("Rust got CppType");
+    generated::print_cpp_type(&c);
+    println!("Rust dropping CppType");
+}

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -141,6 +141,13 @@ pub struct CppValue(pub String, pub String);
 #[derive(Debug, PartialEq, Eq)]
 pub struct CppRef(pub String);
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct CppStackOwned {
+    pub cpp_type: String,
+    pub size: usize,
+    pub align: usize,
+}
+
 impl Display for CppRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -157,6 +164,7 @@ pub struct ZngurType {
     pub fields: Vec<ZngurField>,
     pub cpp_value: Option<CppValue>,
     pub cpp_ref: Option<CppRef>,
+    pub cpp_stack_owned: Option<CppStackOwned>,
 }
 
 #[derive(Debug)]

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AdditionalIncludes, ConvertPanicToException, CppRef, CppValue, LayoutPolicy, ZngurConstructor,
-    ZngurExternCppFn, ZngurExternCppImpl, ZngurField, ZngurFn, ZngurMethodDetails, ZngurSpec,
-    ZngurTrait, ZngurType,
+    AdditionalIncludes, ConvertPanicToException, CppRef, CppStackOwned, CppValue, LayoutPolicy,
+    ZngurConstructor, ZngurExternCppFn, ZngurExternCppImpl, ZngurField, ZngurFn,
+    ZngurMethodDetails, ZngurSpec, ZngurTrait, ZngurType,
 };
 
 /// Trait for types with a partial union operation.
@@ -146,6 +146,7 @@ impl Merge for ZngurType {
 
         self.cpp_value.merge(&mut into.cpp_value)?;
         self.cpp_ref.merge(&mut into.cpp_ref)?;
+        self.cpp_stack_owned.merge(&mut into.cpp_stack_owned)?;
 
         inplace_union(self.wellknown_traits, &mut into.wellknown_traits);
         merge_by_identity(self.methods, &mut into.methods, |a, b| {
@@ -199,6 +200,17 @@ impl Merge for CppRef {
     fn merge(self, into: &mut Self) -> MergeResult {
         if self != *into {
             return Err(MergeFailure::Conflict("Cpp ref mismatch".to_string()));
+        }
+        Ok(())
+    }
+}
+
+impl Merge for CppStackOwned {
+    fn merge(self, into: &mut Self) -> MergeResult {
+        if self != *into {
+            return Err(MergeFailure::Conflict(
+                "Cpp stack owned mismatch".to_string(),
+            ));
         }
         Ok(())
     }

--- a/zngur-generator/src/cpp.rs
+++ b/zngur-generator/src/cpp.rs
@@ -5,7 +5,7 @@ use std::{
 
 use indexmap::IndexMap;
 use itertools::Itertools;
-use zngur_def::{CppRef, CppValue, RustTrait, ZngurFieldData, ZngurMethodReceiver};
+use zngur_def::{CppRef, CppStackOwned, CppValue, RustTrait, ZngurFieldData, ZngurMethodReceiver};
 
 use crate::{
     ZngurWellknownTraitData,
@@ -493,9 +493,22 @@ pub struct CppTypeDefinition {
     pub wellknown_traits: Vec<ZngurWellknownTraitData>,
     pub cpp_value: Option<CppValue>,
     pub cpp_ref: Option<CppRef>,
+    pub cpp_stack_owned: Option<CppStackOwned>,
 }
 
 impl CppTypeDefinition {
+    pub fn rust_short_name(&self) -> String {
+        self.ty.to_string().split("::").last().unwrap().to_string()
+    }
+
+    pub fn cpp_short_name(&self) -> String {
+        if let Some(c) = &self.cpp_stack_owned {
+            c.cpp_type.split("::").last().unwrap().to_string()
+        } else {
+            "".to_string()
+        }
+    }
+
     pub fn has_unsized(&self) -> bool {
         self.wellknown_traits
             .iter()
@@ -612,6 +625,7 @@ impl Default for CppTypeDefinition {
             from_trait_ref: None,
             cpp_value: None,
             cpp_ref: None,
+            cpp_stack_owned: None,
         }
     }
 }
@@ -662,6 +676,7 @@ impl CppFile {
     ) -> std::fmt::Result {
         let template = CppSourceTemplate {
             header_file_name: &self.header_file_name,
+            type_defs: &self.type_defs,
             trait_defs: &self.trait_defs,
             exported_fn_defs: &self.exported_fn_defs,
             exported_impls: &self.exported_impls,

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -81,6 +81,7 @@ impl ZngurGenerator {
                         .unwrap_or_default()
                 )
             }));
+        let mut cpp_mod_content = String::new();
         for ty_def in zng.types {
             let ty = &ty_def.ty;
             let is_copy = ty_def.wellknown_traits.contains(&ZngurWellknownTrait::Copy);
@@ -98,6 +99,36 @@ impl ZngurGenerator {
             }
             if is_copy {
                 rust_file.add_static_is_copy_assert(&ty);
+            }
+            if let Some(cpp_stack_owned) = &ty_def.cpp_stack_owned {
+                let type_name = ty.to_string().split("::").last().unwrap().to_string();
+                let destructor_name = format!("_zngur_crate_{type_name}_destructor");
+                let mangled_name = rust_file.add_extern_cpp_function(
+                    &destructor_name,
+                    &[RustType::Ref(Mutability::Mut, Box::new(ty.clone()))],
+                    &RustType::Tuple(vec![]),
+                );
+                let size = cpp_stack_owned.size;
+                let align = cpp_stack_owned.align;
+                cpp_mod_content.push_str(&format!(
+                    r#"
+    #[repr(C)]
+    #[repr(align({align}))]
+    pub struct {type_name}(pub [u8; {size}]);
+
+    impl Drop for {type_name} {{
+        fn drop(&mut self) {{
+            unsafe {{
+                unsafe extern "C" {{
+                    fn {mangled_name}(i0: *mut u8, o: *mut u8);
+                }}
+                let mut dummy = ();
+                {mangled_name}(self.0.as_mut_ptr(), &mut dummy as *mut () as *mut u8);
+            }}
+        }}
+    }}
+"#
+                ));
             }
             let mut cpp_methods = vec![];
             let mut constructors = vec![];
@@ -223,6 +254,7 @@ impl ZngurGenerator {
                     cpp_value
                 }),
                 cpp_ref: ty_def.cpp_ref,
+                cpp_stack_owned: ty_def.cpp_stack_owned,
                 from_trait: if let RustType::Boxed(b) = &ty {
                     if let RustType::Dyn(tr, _) = b.as_ref() {
                         if let RustTrait::Fn {
@@ -259,6 +291,15 @@ impl ZngurGenerator {
                     None
                 },
             });
+        }
+        if !cpp_mod_content.is_empty() {
+            rust_file.text.push_str(&format!(
+                r#"
+pub mod cpp {{
+{cpp_mod_content}
+}}
+"#
+            ));
         }
         for func in zng.funcs {
             let sig = rust_file.add_function(

--- a/zngur-generator/src/rust.rs
+++ b/zngur-generator/src/rust.rs
@@ -905,6 +905,7 @@ unsafe extern "C" {{ fn {mangled_name}("#
         w!(
             self,
             r#"
+#[allow(non_snake_case)]
 pub fn {rust_name}("#
         );
         for (n, ty) in inputs.iter().enumerate() {

--- a/zngur-generator/src/template.rs
+++ b/zngur-generator/src/template.rs
@@ -544,6 +544,7 @@ impl ZngHeaderTemplate {
 #[template(path = "cpp_source.sptl", escape = "none")]
 pub(crate) struct CppSourceTemplate<'a> {
     pub(crate) header_file_name: &'a String,
+    pub(crate) type_defs: &'a Vec<CppTypeDefinition>,
     pub(crate) trait_defs: &'a IndexMap<RustTrait, CppTraitDefinition>,
     pub(crate) exported_fn_defs: &'a Vec<CppExportedFnDefinition>,
     pub(crate) exported_impls: &'a Vec<CppExportedImplDefinition>,

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -192,6 +192,7 @@ namespace {{ self.namespace }} {
       static inline void assume_init({{ td.ty }}& t) noexcept ;
       static inline void assume_deinit({{ td.ty }}& t) noexcept ;
       static inline size_t size_of() noexcept ;
+      static inline size_t align_of() noexcept ;
     };
   }
 
@@ -366,6 +367,9 @@ namespace {{ self.namespace }} {
 {% if td.layout.is_stack_allocated() %}
   inline size_t __zngur_internal< {{ td.ty }} >::size_of() noexcept {
       return {{ td.layout.stack_size() }};
+  }
+  inline size_t __zngur_internal< {{ td.ty }} >::align_of() noexcept {
+      return {{ td.layout.stack_align() }};
   }
 {% else if !td.layout.is_only_by_ref() %}
   inline size_t __zngur_internal< {{ td.ty }} >::size_of() noexcept {
@@ -561,6 +565,9 @@ namespace {{ self.namespace }} {
     static inline size_t size_of() noexcept {
         return {% if is_unsized %}16{% else %}8{% endif %};
     }
+    static inline size_t align_of() noexcept {
+        return 8;
+    }
   };
 
 } // namespace {{ self.namespace }}
@@ -744,6 +751,9 @@ struct __zngur_internal< {{ ref_kind }} < {{ td.ty }} > > {
   static inline void assume_deinit({{ ref_kind }} < {{ td.ty }} >&) noexcept {}
   static inline size_t size_of() noexcept {
       return {% if is_unsized %}16{% else %}8{% endif %};
+  }
+  static inline size_t align_of() noexcept {
+      return 8;
   }
 };
 

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -321,6 +321,22 @@ namespace {{ self.namespace }} {
           }
       {% endif %}
 
+      {% if let Some(cpp_stack_owned) = td.cpp_stack_owned %}
+          static_assert(sizeof({{ cpp_stack_owned.cpp_type }}) == {{ cpp_stack_owned.size }}, "Size mismatch");
+          static_assert(alignof({{ cpp_stack_owned.cpp_type }}) == {{ cpp_stack_owned.align }}, "Alignment mismatch");
+          static_assert(::{{ self.namespace }}::is_trivially_relocatable< {{ cpp_stack_owned.cpp_type }} >::value, "Type must be trivially relocatable");
+
+          inline {{ cpp_stack_owned.cpp_type }}& cpp() & {
+              return *reinterpret_cast< {{ cpp_stack_owned.cpp_type }}* >(__zngur_data.data());
+          }
+          inline const {{ cpp_stack_owned.cpp_type }}& cpp() const & {
+              return *reinterpret_cast< const {{ cpp_stack_owned.cpp_type }}* >(__zngur_data.data());
+          }
+          inline {{ cpp_stack_owned.cpp_type }}&& cpp() && {
+              return ::std::move(*reinterpret_cast< {{ cpp_stack_owned.cpp_type }}* >(__zngur_data.data()));
+          }
+      {% endif %}
+
     {% endif %}
 
     {% for method in td.methods %}
@@ -518,6 +534,12 @@ namespace {{ self.namespace }} {
       inline RefMut(const {{ cpp_ref.0 }}& t) : __zngur_data(reinterpret_cast<size_t>(&t)) {}
     {% endif %}
 
+    {% if let Some(cpp_stack_owned) = td.cpp_stack_owned %}
+      inline {{ cpp_stack_owned.cpp_type }}& cpp() {
+          return *reinterpret_cast< {{ cpp_stack_owned.cpp_type }}* >(__zngur_data);
+      }
+    {% endif %}
+
     {% for method in td.methods %}
       {% if let ZngurMethodReceiver::Ref(_) = method.kind %}
         {{ method.sig.output }} {{ method.name }}(
@@ -688,6 +710,15 @@ namespace {{ self.namespace }} {
         return *reinterpret_cast< {{ cpp_ref.0 }}* >(__zngur_data);
       }
       inline Ref(const {{ cpp_ref.0 }}& t) : __zngur_data(reinterpret_cast<size_t>(&t)) {}
+    {% endif %}
+
+    {% if let Some(cpp_stack_owned) = td.cpp_stack_owned %}
+      inline const {{ cpp_stack_owned.cpp_type }}& cpp() const {
+        return *reinterpret_cast< const {{ cpp_stack_owned.cpp_type }}* >(__zngur_data);
+      }
+      inline {{ cpp_stack_owned.cpp_type }}& cpp() {
+        return *reinterpret_cast< {{ cpp_stack_owned.cpp_type }}* >(__zngur_data);
+      }
     {% endif %}
 
     {% for method in td.methods %}

--- a/zngur-generator/templates/cpp_source.sptl
+++ b/zngur-generator/templates/cpp_source.sptl
@@ -42,4 +42,14 @@ extern "C" {
   {% endfor %}
 {% endfor %}
 
+{% for td in self.type_defs %}
+  {% if let Some(cpp_stack_owned) = td.cpp_stack_owned %}
+    void _zngur__zngur_crate_{{ td.rust_short_name() }}_destructor_(uint8_t* i0, uint8_t* o) {
+      (void)o;
+      auto* data = reinterpret_cast< {{ cpp_stack_owned.cpp_type }}* >(i0);
+      data->~{{ td.cpp_short_name() }}();
+    }
+  {% endif %}
+{% endfor %}
+
 } // extern "C"

--- a/zngur-generator/templates/zng_header.sptl
+++ b/zngur-generator/templates/zng_header.sptl
@@ -153,6 +153,10 @@ namespace {{ self.cpp_namespace }} {
   template <typename T>
   struct zngur_heap_allocated : ::std::false_type {};
 
+  // specialize to opt-in to stack-owned C++ types
+  template <typename T>
+  struct is_trivially_relocatable : ::std::false_type {};
+
   namespace zngur_detail {
     // std::conjunction analog for c++11 support
     template <typename... Conds>

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -8,11 +8,11 @@ use chumsky::prelude::*;
 use itertools::{Either, Itertools};
 
 use zngur_def::{
-    AdditionalIncludes, ConvertPanicToException, CppRef, CppValue, Import, LayoutPolicy, Merge,
-    MergeFailure, ModuleImport, Mutability, PrimitiveRustType, RustPathAndGenerics, RustTrait,
-    RustType, ZngurConstructor, ZngurExternCppFn, ZngurExternCppImpl, ZngurField, ZngurFn,
-    ZngurMethod, ZngurMethodDetails, ZngurMethodReceiver, ZngurSpec, ZngurTrait, ZngurType,
-    ZngurWellknownTrait,
+    AdditionalIncludes, ConvertPanicToException, CppRef, CppStackOwned, CppValue, Import,
+    LayoutPolicy, Merge, MergeFailure, ModuleImport, Mutability, PrimitiveRustType,
+    RustPathAndGenerics, RustTrait, RustType, ZngurConstructor, ZngurExternCppFn,
+    ZngurExternCppImpl, ZngurField, ZngurFn, ZngurMethod, ZngurMethodDetails, ZngurMethodReceiver,
+    ZngurSpec, ZngurTrait, ZngurType, ZngurWellknownTrait,
 };
 
 pub type Span = SimpleSpan<usize>;
@@ -334,6 +334,10 @@ enum ParsedTypeItem<'a> {
     CppRef {
         cpp_type: &'a str,
     },
+    CppStackOwned {
+        cpp_type: &'a str,
+        props: Vec<(Spanned<&'a str>, usize)>,
+    },
     MatchOnCfg(Condition<CfgConditional<'a>, ParsedTypeItem<'a>, NItems>),
 }
 
@@ -423,52 +427,60 @@ impl ProcessedItem<'_> {
                 let mut layout_span = None;
                 let mut cpp_value = None;
                 let mut cpp_ref = None;
+                let mut cpp_stack_owned = None;
                 let mut to_process = items;
                 to_process.reverse(); // create a stack of items to process
+                let check_size_align = |props: Vec<(Spanned<&str>, usize)>| {
+                    let mut size = None;
+                    let mut align = None;
+                    let mut errors = vec![];
+                    for (key, value) in props {
+                        match key.inner {
+                            "size" => size = Some(value),
+                            "align" => align = Some(value),
+                            _ => errors.push(("Unknown property", key.span)),
+                        }
+                    }
+                    if size.is_none() {
+                        errors.push(("Size is not declared for this type", ty.span));
+                    }
+                    if align.is_none() {
+                        errors.push(("Align is not declared for this type", ty.span));
+                    }
+                    if errors.is_empty() {
+                        Ok((size.unwrap(), align.unwrap()))
+                    } else {
+                        Err(errors)
+                    }
+                };
                 while let Some(item) = to_process.pop() {
                     let item_span = item.span;
                     let item = item.inner;
                     match item {
                         ParsedTypeItem::Layout(span, p) => {
-                            let mut check_size_align = |props: Vec<(Spanned<&str>, usize)>| {
-                                let mut size = None;
-                                let mut align = None;
-                                for (key, value) in props {
-                                    match key.inner {
-                                        "size" => size = Some(value),
-                                        "align" => align = Some(value),
-                                        _ => ctx.add_error_str("Unknown property", key.span),
-                                    }
-                                }
-                                let Some(size) = size else {
-                                    ctx.add_error_str(
-                                        "Size is not declared for this type",
-                                        ty.span,
-                                    );
-                                    return None;
-                                };
-                                let Some(align) = align else {
-                                    ctx.add_error_str(
-                                        "Align is not declared for this type",
-                                        ty.span,
-                                    );
-                                    return None;
-                                };
-                                Some((size, align))
-                            };
                             layout = Some(match p {
                                 ParsedLayoutPolicy::StackAllocated(p) => {
-                                    let Some((size, align)) = check_size_align(p) else {
-                                        continue;
-                                    };
-                                    LayoutPolicy::StackAllocated { size, align }
+                                    match check_size_align(p) {
+                                        Ok((size, align)) => {
+                                            LayoutPolicy::StackAllocated { size, align }
+                                        }
+                                        Err(errs) => {
+                                            for (msg, span) in errs {
+                                                ctx.add_error_str(msg, span);
+                                            }
+                                            continue;
+                                        }
+                                    }
                                 }
-                                ParsedLayoutPolicy::Conservative(p) => {
-                                    let Some((size, align)) = check_size_align(p) else {
+                                ParsedLayoutPolicy::Conservative(p) => match check_size_align(p) {
+                                    Ok((size, align)) => LayoutPolicy::Conservative { size, align },
+                                    Err(errs) => {
+                                        for (msg, span) in errs {
+                                            ctx.add_error_str(msg, span);
+                                        }
                                         continue;
-                                    };
-                                    LayoutPolicy::Conservative { size, align }
-                                }
+                                    }
+                                },
                                 ParsedLayoutPolicy::HeapAllocated => LayoutPolicy::HeapAllocated,
                                 ParsedLayoutPolicy::OnlyByRef => LayoutPolicy::OnlyByRef,
                             });
@@ -547,6 +559,23 @@ impl ProcessedItem<'_> {
                             }
                             cpp_ref = Some(CppRef(cpp_type.to_owned()));
                         }
+                        ParsedTypeItem::CppStackOwned { cpp_type, props } => {
+                            let (size, align) = match check_size_align(props) {
+                                Ok(x) => x,
+                                Err(errs) => {
+                                    for (msg, span) in errs {
+                                        ctx.add_error_str(msg, span);
+                                    }
+                                    continue;
+                                }
+                            };
+                            cpp_stack_owned = Some(CppStackOwned {
+                                cpp_type: cpp_type.to_owned(),
+                                size,
+                                align,
+                            });
+                            layout = Some(LayoutPolicy::StackAllocated { size, align });
+                        }
                         ParsedTypeItem::MatchOnCfg(match_) => {
                             let result = match_.eval(ctx);
                             if let Some(result) = result {
@@ -610,6 +639,7 @@ impl ProcessedItem<'_> {
                             fields,
                             cpp_value,
                             cpp_ref,
+                            cpp_stack_owned,
                         },
                         r,
                         ty.span,
@@ -1633,6 +1663,7 @@ fn inner_type_item<'a>()
         .or(just([Token::Sharp, Token::Ident("layout_conservative")])
             .ignore_then(
                 property_item
+                    .clone()
                     .separated_by(just(Token::Comma))
                     .collect::<Vec<_>>()
                     .delimited_by(just(Token::ParenOpen), just(Token::ParenClose)),
@@ -1724,6 +1755,19 @@ fn inner_type_item<'a>()
             Token::Str(c) => c,
         })
         .map(|x| ParsedTypeItem::CppRef { cpp_type: x });
+    let cpp_stack_owned = just(Token::Sharp)
+        .then(just(Token::Ident("cpp_stack_owned")))
+        .ignore_then(select! {
+            Token::Str(c) => c,
+        })
+        .then(
+            property_item
+                .clone()
+                .separated_by(just(Token::Comma))
+                .collect::<Vec<_>>()
+                .delimited_by(just(Token::ParenOpen), just(Token::ParenClose)),
+        )
+        .map(|(cpp_type, props)| ParsedTypeItem::CppStackOwned { cpp_type, props });
     recursive(|item| {
         let inner_item = choice((
             layout,
@@ -1732,6 +1776,7 @@ fn inner_type_item<'a>()
             field,
             cpp_value,
             cpp_ref,
+            cpp_stack_owned,
             method()
                 .then(
                     just(Token::KwUse)


### PR DESCRIPTION
I'm not sure this is what we want to do for inheritance. We may be able to make the story cleaner by having zngur generate some code for us. However, it works and the foundation is somewhat reusable

I think I would want the following things in zngur if not supporting inheritance out of the box

1. An `assume_init` and a `deinit` function in generated C++ types so i don't have to manually set the drop_flag to true or false (which isn't obvious which one means initialized)
2. Cleaner conversion from rust references, to rust raw pointers, to regular C++ pointers

Then if we want to support inheritance out of the box (which I don't think is a huge uplift), we can autogenerate a good amount of boilerplate for upcasting and downcasting safely. This would be cleaner than my original approach to inheritance since it doesn't need to do anything weird with the vtable anymore as it relies on the actual C++ object