### PR TITLE
Allow marking rust functions `unsafe`

### DIFF
--- a/examples/conditional/expected_output.txt
+++ b/examples/conditional/expected_output.txt
@@ -6,6 +6,15 @@ KVPair(size = 32, align = 8){baz : 3.000000}
 [main.cpp:44] pair = KeyValuePair[f64] { key: "baz", value: 3.0, }
 KVPair(size = 32, align = 8){abc : 4.000000}
 [main.cpp:44] pair = KeyValuePair[f64] { key: "abc", value: 4.0, }
+[main.cpp:46] s.get(0).unwrap() = KeyValuePair[f64] { key: "foo", value: 1.0, }
+[main.cpp:49] s.get(range) = Some(
+    [
+        KeyValuePair[f64] { key: "foo", value: 1.0, },
+        KeyValuePair[f64] { key: "bar", value: 2.0, },
+        KeyValuePair[f64] { key: "baz", value: 3.0, },
+        KeyValuePair[f64] { key: "abc", value: 4.0, },
+    ],
+)
 KVPair(size = 32, align = 8){foo : 1}
 [main.cpp:44] pair = KeyValuePair[i32] { key: "foo", value: 1, }(with debug_assertions)
 KVPair(size = 32, align = 8){bar : 2}
@@ -14,3 +23,12 @@ KVPair(size = 32, align = 8){baz : 3}
 [main.cpp:44] pair = KeyValuePair[i32] { key: "baz", value: 3, }(with debug_assertions)
 KVPair(size = 32, align = 8){abc : 4}
 [main.cpp:44] pair = KeyValuePair[i32] { key: "abc", value: 4, }(with debug_assertions)
+[main.cpp:46] s.get(0).unwrap() = KeyValuePair[i32] { key: "foo", value: 1, }(with debug_assertions)
+[main.cpp:49] s.get(range) = Some(
+    [
+        KeyValuePair[i32] { key: "foo", value: 1, }(with debug_assertions),
+        KeyValuePair[i32] { key: "bar", value: 2, }(with debug_assertions),
+        KeyValuePair[i32] { key: "baz", value: 3, }(with debug_assertions),
+        KeyValuePair[i32] { key: "abc", value: 4, }(with debug_assertions),
+    ],
+)

--- a/examples/conditional/main.cpp
+++ b/examples/conditional/main.cpp
@@ -43,4 +43,8 @@ int main() {
               << " : " << std::to_string(value) << "}\n";
     zngur_dbg(pair);
   }
+  zngur_dbg(s.get(0).unwrap());
+  ::rust::std::ops::RangeFull range;
+  ::rust::__zngur_internal_assume_init(range);
+  zngur_dbg(s.get(range));
 }

--- a/examples/conditional/main.zng
+++ b/examples/conditional/main.zng
@@ -46,6 +46,10 @@ mod crate {
 
 }
 
+type [crate::KeyValuePair] {
+    wellknown_traits(?Sized);
+}
+
 mod ::std {
 
     type option::Option<usize> {
@@ -76,6 +80,20 @@ mod ::std {
         fn unwrap(self) -> &crate::KeyValuePair;
     }
 
+    type option::Option<&[crate::KeyValuePair]> {
+        #layout(size = 16, align = 8);
+        wellknown_traits(Copy, Debug);
+
+        constructor None;
+        constructor Some(&[crate::KeyValuePair]);
+
+        fn unwrap(self) -> &[crate::KeyValuePair];
+    }
+
+    type ::std::ops::RangeFull {
+        #layout(size = 0, align = 1);
+        wellknown_traits(Copy);
+    }
 
     mod vec {
         type Vec<crate::KeyValuePair> {
@@ -85,7 +103,8 @@ mod ::std {
 
             fn new() -> Vec<crate::KeyValuePair>;
             fn push(&mut self, crate::KeyValuePair);
-            fn get(&self, usize) -> ::std::option::Option<&crate::KeyValuePair> deref [crate::KeyValuePair];
+            fn get<usize>(&self, usize) -> ::std::option::Option<&crate::KeyValuePair> deref [crate::KeyValuePair];
+            fn get<::std::ops::RangeFull>(&self, ::std::ops::RangeFull) -> ::std::option::Option<&[crate::KeyValuePair]> deref [crate::KeyValuePair];
             fn iter(&self) -> ::std::slice::Iter<crate::KeyValuePair> deref [crate::KeyValuePair];
         }
     }

--- a/examples/impl_trait/main.zng
+++ b/examples/impl_trait/main.zng
@@ -42,5 +42,5 @@ mod crate {
     fn async_func1() -> impl ::std::future::Future<Output = i32>;
     async fn async_func2() -> i32;
     async fn impl_future() -> i32;
-    fn busy_wait_future(Box<dyn ::std::future::Future<Output = i32>>) -> i32;
+    fn busy_wait_future<i32>(Box<dyn ::std::future::Future<Output = i32>>) -> i32;
 }

--- a/examples/memory_management/main.zng
+++ b/examples/memory_management/main.zng
@@ -39,7 +39,7 @@ mod crate {
     type [PrintOnDrop] {
         wellknown_traits(?Sized);
 
-        fn get(&self, usize) -> ::std::option::Option<&crate::PrintOnDrop>;    
+        fn get<usize>(&self, usize) -> ::std::option::Option<&crate::PrintOnDrop>;    
     }
 
     trait PrintOnDropConsumer {
@@ -97,7 +97,7 @@ mod ::std {
             fn new() -> Vec<crate::PrintOnDrop>;
             fn push(&mut self, crate::PrintOnDrop);
             fn clone(&self) -> Vec<crate::PrintOnDrop>;
-            fn get(&self, usize) -> ::std::option::Option<&crate::PrintOnDrop> deref [crate::PrintOnDrop];
+            fn get<usize>(&self, usize) -> ::std::option::Option<&crate::PrintOnDrop> deref [crate::PrintOnDrop];
             fn deref(&self) -> &[crate::PrintOnDrop] use ::std::ops::Deref;
         }
     }

--- a/examples/raw_pointer/main.zng
+++ b/examples/raw_pointer/main.zng
@@ -36,7 +36,7 @@ mod ::std {
             fn push(&mut self, i32);
             fn clone(&self) -> Vec<i32>;
             fn reserve(&mut self, usize);
-            fn set_len(&mut self, usize);
+            unsafe fn set_len(&mut self, usize);
             fn as_mut_ptr(&mut self) -> *mut i32;
         }
 
@@ -47,9 +47,9 @@ mod ::std {
             fn new() -> Vec<Vec<i32>>;
             fn push(&mut self, Vec<i32>);
             fn clone(&self) -> Vec<Vec<i32>>;
-            fn get_mut(&mut self, usize) -> ::std::option::Option<&mut Vec<i32>> deref [Vec<i32>];
+            fn get_mut<usize>(&mut self, usize) -> ::std::option::Option<&mut Vec<i32>> deref [Vec<i32>];
             fn reserve(&mut self, usize);
-            fn set_len(&mut self, usize);
+            unsafe fn set_len(&mut self, usize);
             fn as_mut_ptr(&mut self) -> *mut Vec<i32>;
             fn as_ptr(&self) -> *const Vec<i32>;
         }

--- a/examples/rayon/main.zng
+++ b/examples/rayon/main.zng
@@ -38,10 +38,10 @@ type ::rayon::iter::Copied<::rayon::slice::Iter<u64>> {
 type [u64] {
     wellknown_traits(?Sized);
 
-    fn get(&self, usize) -> ::std::option::Option<&u64>;
+    fn get<usize>(&self, usize) -> ::std::option::Option<&u64>;
     fn par_iter(&self) -> ::rayon::slice::Iter<u64> use ::rayon::iter::IntoParallelRefIterator;
 }
 
 mod ::std::slice {
-    fn from_raw_parts(*const u64, usize) -> &[u64];
+    unsafe fn from_raw_parts<u64>(*const u64, usize) -> &[u64];
 }

--- a/examples/rayon_split/main.zng
+++ b/examples/rayon_split/main.zng
@@ -38,10 +38,10 @@ type ::rayon::iter::Copied<::rayon::slice::Iter<u64>> {
 type [u64] {
     wellknown_traits(?Sized);
 
-    fn get(&self, usize) -> ::std::option::Option<&u64>;
+    fn get<usize>(&self, usize) -> ::std::option::Option<&u64>;
     fn par_iter(&self) -> ::rayon::slice::Iter<u64> use ::rayon::iter::IntoParallelRefIterator;
 }
 
 mod ::std::slice {
-    fn from_raw_parts(*const u64, usize) -> &[u64];
+    unsafe fn from_raw_parts<u64>(*const u64, usize) -> &[u64];
 }

--- a/examples/regression_test1/main.zng
+++ b/examples/regression_test1/main.zng
@@ -110,8 +110,8 @@ mod ::std::vec {
         wellknown_traits(Debug);
 
         fn new() -> Vec<f32>;
-        fn get(&self, usize) -> ::std::option::Option<&f32> deref [f32];
-        fn get_mut(&mut self, usize) -> ::std::option::Option<&mut f32> deref [f32];
+        fn get<usize>(&self, usize) -> ::std::option::Option<&f32> deref [f32];
+        fn get_mut<usize>(&mut self, usize) -> ::std::option::Option<&mut f32> deref [f32];
         fn push(&mut self, f32);
     }
 
@@ -120,8 +120,8 @@ mod ::std::vec {
         wellknown_traits(Debug);
 
         fn new() -> Vec<&str>;
-        fn get(&self, usize) -> ::std::option::Option<&&str> deref [&str];
-        fn get_mut(&mut self, usize) -> ::std::option::Option<&mut &str> deref [&str];
+        fn get<usize>(&self, usize) -> ::std::option::Option<&&str> deref [&str];
+        fn get_mut<usize>(&mut self, usize) -> ::std::option::Option<&mut &str> deref [&str];
         fn push(&mut self, &str);
     }
 
@@ -130,8 +130,8 @@ mod ::std::vec {
         wellknown_traits(Debug);
 
         fn new() -> Vec<crate::ConservativeLayoutType>;
-        fn get(&self, usize) -> ::std::option::Option<&crate::ConservativeLayoutType> deref [crate::ConservativeLayoutType];
-        fn get_mut(&mut self, usize) -> ::std::option::Option<&mut crate::ConservativeLayoutType> deref [crate::ConservativeLayoutType];
+        fn get<usize>(&self, usize) -> ::std::option::Option<&crate::ConservativeLayoutType> deref [crate::ConservativeLayoutType];
+        fn get_mut<usize>(&mut self, usize) -> ::std::option::Option<&mut crate::ConservativeLayoutType> deref [crate::ConservativeLayoutType];
         fn push(&mut self, crate::ConservativeLayoutType);
     }
 }

--- a/examples/simple/expected_output.txt
+++ b/examples/simple/expected_output.txt
@@ -1,7 +1,7 @@
 17
 s[2] = 7
 
-thread panicked at examples/simple/src/generated.rs:351:40:
+thread panicked at examples/simple/src/generated.rs:355:40:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 s[4] = Rust panic happened

--- a/examples/simple/main.zng
+++ b/examples/simple/main.zng
@@ -44,7 +44,7 @@ mod ::std {
             fn new() -> Vec<i32>;
             fn push(&mut self, i32);
             fn clone(&self) -> Vec<i32>;
-            fn get(&self, usize) -> ::std::option::Option<&i32> deref [i32];
+            fn get<usize>(&self, usize) -> ::std::option::Option<&i32> deref [i32];
             fn into_iter(self) -> ::std::vec::IntoIter<i32>;
         }
     }

--- a/examples/tutorial-wasm32/main32.zng
+++ b/examples/tutorial-wasm32/main32.zng
@@ -42,7 +42,7 @@ mod ::std {
             fn new() -> Vec<i32>;
             fn push(&mut self, i32);
             fn clone(&self) -> Vec<i32>;
-            fn get(&self, usize) -> ::std::option::Option<&i32> deref [i32];
+            fn get<usize>(&self, usize) -> ::std::option::Option<&i32> deref [i32];
             fn into_iter(self) -> ::std::vec::IntoIter<i32>;
         }
     }

--- a/examples/tutorial_cpp/main.zng
+++ b/examples/tutorial_cpp/main.zng
@@ -12,7 +12,7 @@ type str {
 type ::std::ffi::CStr {
     wellknown_traits(?Sized);
 
-    fn from_ptr(*const i8) -> &::std::ffi::CStr;
+    unsafe fn from_ptr(*const i8) -> &::std::ffi::CStr;
     fn to_str(&self) -> ::std::result::Result<&str, ::std::str::Utf8Error>;
 }
 

--- a/examples/unsafe_fns/expected_output.txt
+++ b/examples/unsafe_fns/expected_output.txt
@@ -1,1 +1,3 @@
+Called unsafe Rust function!
+Called safe Rust function!
 Dangerous result: 42

--- a/examples/unsafe_fns/main.zng
+++ b/examples/unsafe_fns/main.zng
@@ -1,3 +1,9 @@
+type crate::RustStruct {
+    #layout(size = 0, align = 1);
+    unsafe fn unsafe_rust_fn();
+    fn safe_rust_fn();
+}
+
 extern "C++" {
     unsafe fn dangerous_function() -> i32;
 }

--- a/examples/unsafe_fns/src/main.rs
+++ b/examples/unsafe_fns/src/main.rs
@@ -1,6 +1,27 @@
 #[rustfmt::skip]
 mod generated;
 
+pub struct RustStruct;
+
+impl RustStruct {
+    pub unsafe fn unsafe_rust_fn() {
+        println!("Called unsafe Rust function!");
+    }
+
+    // To test that signature verification works:
+    // 1. Comment out the safe definition below.
+    // 2. Uncomment the unsafe definition below.
+    // 3. Run `cargo build` and verify it fails because it is marked as safe in .zng.
+
+    pub fn safe_rust_fn() {
+        println!("Called safe Rust function!");
+    }
+
+    // pub unsafe fn safe_rust_fn() {
+    //     println!("Called unsafe Rust function!");
+    // }
+}
+
 fn main() {
     let result = unsafe { generated::dangerous_function() };
     println!("Dangerous result: {}", result);

--- a/examples/unsafe_fns/unsafe_fn.cpp
+++ b/examples/unsafe_fns/unsafe_fn.cpp
@@ -4,6 +4,8 @@
 namespace rust {
 namespace exported_functions {
     int32_t dangerous_function() {
+        rust::crate::RustStruct::unsafe_rust_fn();
+        rust::crate::RustStruct::safe_rust_fn();
         return 42;
     }
 }

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -34,6 +34,7 @@ pub struct ZngurFn {
     pub path: RustPathAndGenerics,
     pub inputs: Vec<RustType>,
     pub output: RustType,
+    pub is_safe: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -276,6 +276,7 @@ impl ZngurGenerator {
                     &method.output,
                     use_path,
                     deref.map(|x| x.1),
+                    method.is_safe,
                     default_ns,
                     &sanitized_crate_name,
                 );
@@ -351,6 +352,7 @@ pub mod cpp {{
                 &func.output,
                 None,
                 None,
+                func.is_safe,
                 default_ns,
                 &sanitized_crate_name,
             );

--- a/zngur-generator/src/rust.rs
+++ b/zngur-generator/src/rust.rs
@@ -924,6 +924,7 @@ pub extern "C" fn {mangled_name}(d: *mut u8) -> *mut cpp::{type_name} {{
         output: &RustType,
         use_path: Option<Vec<String>>,
         deref: Option<Mutability>,
+        is_safe: bool,
         namespace: &str,
         crate_name: &str,
     ) -> CppFnSig {
@@ -950,16 +951,26 @@ pub extern "C" fn {mangled_name}("#
         } else {
             (output.clone(), false)
         };
-        wln!(self, "o: *mut u8) {{ unsafe {{");
-        self.wrap_in_catch_unwind(|this| {
-            if let Some(use_path) = use_path {
-                if use_path.first().is_some_and(|x| x == "crate") {
-                    wln!(this, "    use {};", use_path.iter().join("::"));
-                } else {
-                    wln!(this, "    use ::{};", use_path.iter().join("::"));
-                }
-            }
+        wln!(self, "o: *mut u8) {{");
 
+        if let Some(use_path) = use_path {
+            if use_path.first().is_some_and(|x| x == "crate") {
+                wln!(self, "    use {};", use_path.iter().join("::"));
+            } else {
+                wln!(self, "    use ::{};", use_path.iter().join("::"));
+            }
+        }
+        if is_safe {
+            let loops = (0..inputs.len()).map(|_| "loop {}").join(", ");
+            wln!(
+                self,
+                "    const {{ let _verify_safety = || {{ #[allow(unreachable_code)] let _ = {}({}); }}; }};",
+                rust_name,
+                loops
+            );
+        }
+        wln!(self, "unsafe {{");
+        self.wrap_in_catch_unwind(|this| {
             w!(
                 this,
                 "    ::std::ptr::write(o as *mut {modified_output}, {impl_trait} {rust_name}(",

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -247,7 +247,7 @@ enum ParsedItem<'a> {
         tr: Spanned<ParsedRustTrait<'a>>,
         methods: Vec<ParsedMethod<'a>>,
     },
-    Fn(Spanned<ParsedMethod<'a>>),
+    Fn(bool, Spanned<ParsedMethod<'a>>),
     ExternCpp(Vec<ParsedExternCppItem<'a>>),
     Alias(ParsedAlias<'a>),
     Import(ParsedImportPath),
@@ -275,7 +275,7 @@ enum ProcessedItem<'a> {
         tr: Spanned<ParsedRustTrait<'a>>,
         methods: Vec<ParsedMethod<'a>>,
     },
-    Fn(Spanned<ParsedMethod<'a>>),
+    Fn(bool, Spanned<ParsedMethod<'a>>),
     ExternCpp(Vec<ParsedExternCppItem<'a>>),
     Import(ParsedImportPath),
     ModuleImport {
@@ -329,6 +329,7 @@ enum ParsedTypeItem<'a> {
         data: ParsedMethod<'a>,
         use_path: Option<ParsedPath<'a>>,
         deref: Option<ParsedRustType<'a>>,
+        is_safe: bool,
     },
     CppValue {
         field: &'a str,
@@ -526,6 +527,7 @@ impl ProcessedItem<'_> {
                             data,
                             use_path,
                             deref,
+                            is_safe,
                         } => {
                             let deref = deref.and_then(|x| {
                                 let deref_type = x.to_zngur(scope);
@@ -542,7 +544,11 @@ impl ProcessedItem<'_> {
                                 Some((deref_type, receiver_mutability))
                             });
                             methods.push(ZngurMethodDetails {
-                                data: data.to_zngur(scope),
+                                data: {
+                                    let mut m = data.to_zngur(scope);
+                                    m.is_safe = is_safe;
+                                    m
+                                },
                                 use_path: use_path.map(|x| scope.resolve_path(x)),
                                 deref,
                             });
@@ -668,7 +674,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                     ctx,
                 );
             }
-            ProcessedItem::Fn(f) => {
+            ProcessedItem::Fn(is_safe, f) => {
                 let method = f.inner.to_zngur(scope);
                 checked_merge(
                     ZngurFn {
@@ -679,6 +685,7 @@ Use one of `#layout(size = X, align = Y)`, `#heap_allocated` or `#only_by_ref`."
                         },
                         inputs: method.inputs,
                         output: method.output,
+                        is_safe,
                     },
                     r,
                     f.span,
@@ -1176,7 +1183,7 @@ fn process_parsed_item<'a>(
         }
         ParsedItem::Type { ty, items } => Ret::Processed(ProcessedItem::Type { ty, items }),
         ParsedItem::Trait { tr, methods } => Ret::Processed(ProcessedItem::Trait { tr, methods }),
-        ParsedItem::Fn(method) => Ret::Processed(ProcessedItem::Fn(method)),
+        ParsedItem::Fn(is_safe, method) => Ret::Processed(ProcessedItem::Fn(is_safe, method)),
         ParsedItem::ExternCpp(items) => Ret::Processed(ProcessedItem::ExternCpp(items)),
         ParsedItem::Import(path) => Ret::Processed(ProcessedItem::Import(path)),
         ParsedItem::ModuleImport { path, span } => {
@@ -1791,7 +1798,9 @@ fn inner_type_item<'a>()
             cpp_value,
             cpp_ref,
             cpp_stack_owned,
-            method()
+            just(Token::KwUnsafe)
+                .or_not()
+                .then(method())
                 .then(
                     just(Token::KwUse)
                         .ignore_then(path())
@@ -1804,11 +1813,14 @@ fn inner_type_item<'a>()
                         .map(Some)
                         .or(empty().to(None)),
                 )
-                .map(|((data, use_path), deref)| ParsedTypeItem::Method {
-                    deref,
-                    use_path,
-                    data,
-                }),
+                .map(
+                    |(((opt_unsafe, data), use_path), deref)| ParsedTypeItem::Method {
+                        deref,
+                        use_path,
+                        data,
+                        is_safe: opt_unsafe.is_none(),
+                    },
+                ),
         ));
 
         let match_stmt =
@@ -1847,9 +1859,14 @@ fn trait_item<'a>() -> impl Parser<'a, ParserInput<'a>, ParsedItem<'a>, ZngParse
 }
 
 fn fn_item<'a>() -> impl Parser<'a, ParserInput<'a>, ParsedItem<'a>, ZngParserExtra<'a>> + Clone {
-    spanned(method())
+    let safety = choice((just(Token::KwUnsafe).to(false),))
+        .or_not()
+        .map(|x| x.unwrap_or(true));
+
+    safety
+        .then(spanned(method()))
         .then_ignore(just(Token::Semicolon))
-        .map(ParsedItem::Fn)
+        .map(|(is_safe, method)| ParsedItem::Fn(is_safe, method))
 }
 
 fn additional_include_item<'a>()

--- a/zngur-parser/src/tests.rs
+++ b/zngur-parser/src/tests.rs
@@ -122,12 +122,12 @@ type () {
 }
     "#,
         expect![[r#"
-            Error: found 'welcome_traits' expected '#', 'wellknown_traits', 'constructor', 'field', 'async', 'fn', or '}'
+            Error: found 'welcome_traits' expected '#', 'wellknown_traits', 'constructor', 'field', 'unsafe', 'async', 'fn', or '}'
                ╭─[test.zng:4:5]
                │
              4 │     welcome_traits(Copy);
                │     ───────┬──────  
-               │            ╰──────── found 'welcome_traits' expected '#', 'wellknown_traits', 'constructor', 'field', 'async', 'fn', or '}'
+               │            ╰──────── found 'welcome_traits' expected '#', 'wellknown_traits', 'constructor', 'field', 'unsafe', 'async', 'fn', or '}'
             ───╯
         "#]],
     );
@@ -965,4 +965,51 @@ extern "C++" {
             ───╯
         "#]],
     );
+}
+
+#[test]
+fn parse_unsafe_method() {
+    let parsed = crate::ParsedZngFile::parse_str(
+        r#"
+type A {
+    #layout(size = 1, align = 1);
+    unsafe fn is_unsafe(i32) -> i32;
+    fn is_safe(i32) -> i32;
+}
+
+mod bar::baz {
+    unsafe fn is_unsafe(i32) -> i32;
+    fn is_safe(i32) -> i32;
+}
+    "#,
+        crate::cfg::NullCfg,
+    );
+    let ty = parsed.spec.types.first().expect("no type parsed");
+    let unsafe_fn = ty
+        .methods
+        .iter()
+        .find(|m| m.data.name == "is_unsafe")
+        .expect("Missing method");
+    assert!(!unsafe_fn.data.is_safe);
+    let safe_fn = ty
+        .methods
+        .iter()
+        .find(|m| m.data.name == "is_safe")
+        .expect("Missing method");
+    assert!(safe_fn.data.is_safe);
+
+    let unsafe_fn = parsed
+        .spec
+        .funcs
+        .iter()
+        .find(|fun| fun.path.path.last().unwrap() == "is_unsafe")
+        .expect("Missing method");
+    assert!(!unsafe_fn.is_safe);
+    let safe_fn = parsed
+        .spec
+        .funcs
+        .iter()
+        .find(|fun| fun.path.path.last().unwrap() == "is_safe")
+        .expect("Missing method");
+    assert!(safe_fn.is_safe);
 }


### PR DESCRIPTION
Note: This change requires that functions specializations are explicit on the Rust side, whereas before you could leave the specialized type out of the .zng declaration since the compiler was smart enough to figure out those specializations.