### PR TITLE
Improve `rust::Bool` to align with rust's `bool` validity constraints

### DIFF
--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -289,11 +289,7 @@ namespace {{ self.namespace }} {
 
     public:
       {% if is_copy %}
-        {% if td.ty.path.to_string() == format!("::{}::Bool", self.namespace) %}
-        {{ name }}() { __zngur_data[0] = 0; }
-        {% else %}
         {{ name }}() { {{ alloc_heap }} }
-        {% endif %}
         ~{{ name }}() { {{ free_heap }} }
         {{ name }}(const {{ name }}& other) {
           {{ alloc_heap }}

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -239,9 +239,10 @@ namespace {{ self.namespace }} {
 
     {% if td.ty.path.to_string() == format!("::{}::Bool", self.namespace) %}
       public:
-        operator bool() {
+        operator bool() const noexcept {
           return __zngur_data[0];
         }
+        operator int() = delete;
         Bool(bool b) {
           __zngur_data[0] = b;
         }
@@ -267,7 +268,11 @@ namespace {{ self.namespace }} {
 
     public:
       {% if is_copy %}
+        {% if td.ty.path.to_string() == format!("::{}::Bool", self.namespace) %}
+        {{ name }}() { __zngur_data[0] = 0; }
+        {% else %}
         {{ name }}() { {{ alloc_heap }} }
+        {% endif %}
         ~{{ name }}() { {{ free_heap }} }
         {{ name }}(const {{ name }}& other) {
           {{ alloc_heap }}

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -242,7 +242,7 @@ namespace {{ self.namespace }} {
         operator bool() const noexcept {
           return __zngur_data[0];
         }
-        operator int() = delete;
+        operator int() const = delete;
         Bool(bool b) {
           __zngur_data[0] = b;
         }

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -249,6 +249,24 @@ namespace {{ self.namespace }} {
         friend ::std::ostream& operator<<(::std::ostream& os, const Bool& b) {
           return os << static_cast<bool>(b);
         }
+        friend bool operator==(const Bool& a, const Bool& b) {
+          return static_cast<bool>(a) == static_cast<bool>(b);
+        }
+        friend bool operator==(const Bool& a, bool b) {
+          return static_cast<bool>(a) == b;
+        }
+        friend bool operator==(bool a, const Bool& b) {
+          return a == static_cast<bool>(b);
+        }
+        friend bool operator!=(const Bool& a, const Bool& b) {
+          return static_cast<bool>(a) != static_cast<bool>(b);
+        }
+        friend bool operator!=(const Bool& a, bool b) {
+          return static_cast<bool>(a) != b;
+        }
+        friend bool operator!=(bool a, const Bool& b) {
+          return a != static_cast<bool>(b);
+        }
     {% endif %}
 
     {% if td.ty.path.to_string() == format!("::{}::Char", self.namespace) %}

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -246,6 +246,9 @@ namespace {{ self.namespace }} {
         Bool(bool b) {
           __zngur_data[0] = b;
         }
+        friend ::std::ostream& operator<<(::std::ostream& os, const Bool& b) {
+          return os << static_cast<bool>(b);
+        }
     {% endif %}
 
     {% if td.ty.path.to_string() == format!("::{}::Char", self.namespace) %}


### PR DESCRIPTION
Rust `bool` must be `0x00` or `0x01` — other byte values are invalid representations causing UB. Rust `bool` also does not support arithmetic.
This PR makes `rust::Bool` respect these constraints:

- `operator bool() const noexcept` — enable const usage, consistent with `Char::operator char32_t() const`
- `Bool() { __zngur_data[0] = 0; }` — zero-initialize to avoid invalid Rust bool representation
- `operator int() const = delete` — block implicit arithmetic via `bool->int` promotion. Deleting only `operator int()` suffices because the compiler encounters ambiguity between `operator bool` and `operator int` for all arithmetic conversions, effectively blocking `float`, `short`, etc. as well
- `friend operator<<`, `friend operator==`, `friend operator!=` — resolve overload ambiguity for `ostream` output and comparisons, caused by the deleted `operator int()` still participating in overload resolution