### PR TITLE
generate enum variant accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-enums"
+version = "0.10.0"
+
+[[package]]
 name = "example-impl-trait"
 version = "0.10.0"
 
@@ -537,6 +541,10 @@ dependencies = [
  "processor",
  "receiver",
 ]
+
+[[package]]
+name = "example-overloaded-trait"
+version = "0.10.0"
 
 [[package]]
 name = "example-raw-pointer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 name = "benchmark"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.1.2",
  "cc",
  "criterion",
  "zngur",
@@ -200,6 +200,15 @@ name = "build-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00b8763668c99f8d9101b8a0dd82106f58265464531a79b2cef0d9a30c17dd2"
+
+[[package]]
+name = "build-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe808acca98fccf920154ee7833e791bfb683299be4aae7ec222ddffad8cd4f8"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "bumpalo"
@@ -486,7 +495,7 @@ version = "0.10.0"
 name = "example-cpp-inheritance"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.1.2",
  "cc",
  "cpp_inherit",
  "zngur",
@@ -497,7 +506,7 @@ dependencies = [
 name = "example-cxx_demo"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.1.2",
  "cc",
  "zngur",
 ]
@@ -506,7 +515,7 @@ dependencies = [
 name = "example-cxx_demo_split"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.1.2",
  "cc",
  "zngur",
 ]
@@ -570,7 +579,7 @@ version = "0.10.0"
 name = "example-stack-owned"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.1.2",
  "cc",
  "zngur",
  "zngur-lib",
@@ -588,7 +597,7 @@ version = "0.10.0"
 name = "example-tutorial_cpp"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.3.4",
  "cc",
  "zngur",
 ]
@@ -597,7 +606,7 @@ dependencies = [
 name = "example-unsafe_fns"
 version = "0.10.0"
 dependencies = [
- "build-rs",
+ "build-rs 0.1.2",
  "cc",
  "zngur",
 ]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Well-known traits](./call_rust_from_cpp/wellknown_traits.md)
   - [Layout policy](./call_rust_from_cpp/layout_policy.md)
   - [Fields](./call_rust_from_cpp/fields.md)
+  - [Variants](./call_rust_from_cpp/variants.md)
   - [Types with special support](./call_rust_from_cpp/special_types.md)
   - [Panic and exceptions](./call_rust_from_cpp/panic_and_exceptions.md)
   - [Raw pointers](./call_rust_from_cpp/raw_pointers.md)

--- a/book/src/call_rust_from_cpp/name_mapping.md
+++ b/book/src/call_rust_from_cpp/name_mapping.md
@@ -88,8 +88,13 @@ mod ::std::net {
     type IpAddr {
         #layout(size = 17, align = 1);
 
-        constructor V4(Ipv4Addr);
-        constructor V6(Ipv6Addr);
+        variant V4 {
+            field 0 (offset = auto, type = Ipv4Addr);
+        }
+
+        variant V6 {
+            field 0 (offset = auto, type = Ipv6Addr);
+        }
 
         fn partial_cmp(&self, &Ipv4Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;
         // renaming not needed since the argument types differ

--- a/book/src/call_rust_from_cpp/variants.md
+++ b/book/src/call_rust_from_cpp/variants.md
@@ -1,0 +1,72 @@
+# Enum variants
+
+Enum variants can be declared with `variant name { }` syntax.
+Inside the block you can specify the fields of a variant,
+similarly to how struct fields are declared:
+
+```
+type ::std::option::Option<i32> {
+    variant None { }
+    variant Some {
+        field 0 (offset = auto, type = i32);
+    }
+}
+```
+
+Note that due to technical limitations only `auto` offsets are supported.
+
+By default, if any variants are declared, zngur will verify at compile time
+that declarations are exhaustive, i.e. no variants and no variant fields are missing. `non_exhaustive` declaration can be used to disable this check.
+
+```
+type ::std::option::Option<i32> {
+    non_exhaustive; // Some variants might be missing.
+    variant Some {
+        non_exhaustive; // Some variant fields might be missing.
+    }
+}
+```
+
+For every declared variant zngur will generate a nested class.
+If a variant is exhaustive, this class will have a constructor to build it from fields:
+
+```C++
+template<class T> using Option = rust::std::option::Option<T>;
+
+Option<int> opt = Option<int>::Some(42);
+```
+
+Each variant class has a `::match()` static method returning `std::optional` to check if the enum contains that variant:
+
+```C++
+if (auto r = Option<int>::Some::match(v)) {
+    std::cout << r->f0 << std::endl;
+}
+```
+
+`::match_ref()` and `::match_mut()` static methods can similarly be used for by-ref matching,
+returning `std::optional<Ref<_>>` and `std::optional<RefMut<_>>` respectively.
+
+These methods are only available on C++17 or higher, since they require `std::optional`.
+
+If you don't need the fields, you can also use the `::check()` static method:
+
+```C++
+if (Option<int>::None::check(v)) {
+    std::cout << "is none" << std::endl;
+}
+```
+
+Alternatively, `.match()` methods on the enum class can be used to convert the enum into `std::variant`
+of variant classes (or refs to variant classes):
+
+```C++
+std::visit(overloaded{
+    [](rust::Ref<Option<int>::None>) { std::cout << "none" << std::endl; },
+    [](rust::Ref<Option<int>::Some> s) { std::cout << "some " << s.f0 << std::endl; },
+}, v.match_ref());
+```
+
+This is also only available starting with C++17.
+
+See `examples/enums` for a runnable demonstration.

--- a/book/src/import.md
+++ b/book/src/import.md
@@ -73,8 +73,10 @@ mod ::std {
         #layout(size = 8, align = 4);
         wellknown_traits(Copy);
 
-        constructor None;
-        constructor Some(i32);
+        variant None { }
+        variant Some {
+            field 0 (offset = auto, type = i32);
+        }
 
         fn unwrap(self) -> i32;
     }
@@ -160,8 +162,10 @@ mod ::crate {
         #layout(size = 8, align = 4);
         wellknown_traits(Copy);
 
-        constructor None;
-        constructor Some(i32);
+        variant None { }
+        variant Some {
+            field 0 (offset = auto, type = i32);
+        }
 
         fn unwrap(self) -> i32;
     }

--- a/book/src/template_types.md
+++ b/book/src/template_types.md
@@ -8,8 +8,10 @@ For example:
 #unstable(template_types)
 
 type<T> ::std::option::Option<T> {
-    constructor Some(T);
-    constructor None;
+    variant Some {
+        field 0 (offset = auto, type = T);
+    }
+    variant None { }
     fn unwrap(self) -> T;
     fn is_some(&self) -> bool;
 }

--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -560,8 +560,6 @@ type ::std::result::Result<&str, ::std::str::Utf8Error> {
 
 type ::std::fmt::Result {
     #layout(size = 1, align = 1);
-
-    constructor Ok(());
 }
 
 type ::std::fmt::Formatter {

--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -52,6 +52,8 @@ newtype
 noexcept
 nmake
 ntdll
+nullopt
+nullptr
 pmut
 primitve
 println

--- a/examples/char/NMakefile
+++ b/examples/char/NMakefile
@@ -1,6 +1,6 @@
 CXX = cl.exe
 # MSVC doesn't support earlier that c++14
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++14 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++14 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = char

--- a/examples/conditional/NMakefile
+++ b/examples/conditional/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib Userenv.lib Ws2_32.lib
 
 EXAMPLE_NAME = conditional

--- a/examples/conditional/main.cpp
+++ b/examples/conditional/main.cpp
@@ -31,8 +31,8 @@ int main() {
     s.push(KVPair{key.to_owned(), static_cast<KVPairValue_T>(value)});
   }
   auto it = s.iter();
-  for (auto next = it.next(); next.matches_Some(); next = it.next()) {
-    auto pair = next.unwrap();
+  for (auto next = it.next(); auto some = Option<rust::Ref<KVPair>>::Some::match(next); next = it.next()) {
+    rust::Ref<KVPair> pair = some->f0;
     rust::Ref<rust::std::string::String> key = pair.key;
     KVPairValue_T value = pair.value;
     std::cout << "KVPair(size = " << KVPair::self_size()

--- a/examples/conditional/main.zng
+++ b/examples/conditional/main.zng
@@ -51,29 +51,29 @@ mod ::std {
     type option::Option<usize> {
         #layout(size = 16, align = 8);
 
-        constructor None;
-        constructor Some(usize);
-
-        fn unwrap(self) -> usize;
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = usize);
+        }
     }
 
     type option::Option<crate::KeyValuePair> {
         #layout(size = 32, align = 8);
 
-        constructor None;
-        constructor Some(crate::KeyValuePair);
-
-        fn unwrap(self) -> crate::KeyValuePair;
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = crate::KeyValuePair);
+        }
     }
 
     type option::Option<&crate::KeyValuePair> {
         #layout(size = 8, align = 8);
         wellknown_traits(Copy);
 
-        constructor None;
-        constructor Some(&crate::KeyValuePair);
-
-        fn unwrap(self) -> &crate::KeyValuePair;
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = &crate::KeyValuePair);
+        }
     }
 
 

--- a/examples/enums/.gitignore
+++ b/examples/enums/.gitignore
@@ -1,0 +1,3 @@
+generated.h
+generated.rs
+generated.cpp

--- a/examples/enums/Cargo.toml
+++ b/examples/enums/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-enums"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/enums/Makefile
+++ b/examples/enums/Makefile
@@ -1,0 +1,13 @@
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_enums.a
+	${CXX} -std=c++17 -Werror main.cpp  -g -L ../../target/release/ -l example_enums
+
+../../target/release/libexample_enums.a:
+	cargo build --release
+
+generated.h ./src/generated.rs: main.zng
+	cd ../../zngur-cli && cargo run g -i ../examples/enums/main.zng --crate-name "crate"
+
+.PHONY: ../../target/release/libexample_enums.a generated.h clean
+
+clean:
+	rm -f generated.h src/generated.rs a.out actual_output.txt

--- a/examples/enums/NMakefile
+++ b/examples/enums/NMakefile
@@ -1,0 +1,23 @@
+CXX = cl.exe
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
+WINLIBS = ntdll.lib
+
+EXAMPLE_NAME = enums
+
+GENERATED = generated.h src/generated.rs
+
+RUSTLIB_PATH = ../../target/release/
+
+RUSTLIB = example_$(EXAMPLE_NAME).lib
+
+a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
+	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
+
+$(RUSTLIB_PATH)/$(RUSTLIB) :
+	cargo build --release
+
+$(GENERATED) : main.zng
+	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"
+
+clean :
+	- del /f /q generated.h src\generated.rs a.exe main.obj generated.obj actual_output.txt 2>nul

--- a/examples/enums/README.md
+++ b/examples/enums/README.md
@@ -1,0 +1,10 @@
+# Example: Enums
+
+Showcases some methods of working with Rust enums.
+
+To run this example:
+
+```
+make
+./a.out
+```

--- a/examples/enums/expected_output.txt
+++ b/examples/enums/expected_output.txt
@@ -1,0 +1,6 @@
+some 42
+67!!
+is some
+some 1337
+first: 42
+second: 24

--- a/examples/enums/main.cpp
+++ b/examples/enums/main.cpp
@@ -1,0 +1,51 @@
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
+#include "./generated.h"
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+template<class T> using Option = rust::std::option::Option<T>;
+using Merged = rust::crate::Merged;
+
+int main() {
+    Option<int> v = Option<int>::Some(42);
+    std::visit(overloaded{
+        [](Option<int>::None) { std::cout << "none" << std::endl; },
+        [](Option<int>::Some s) { std::cout << "some " << s.f0 << std::endl; },
+    }, v.match());
+
+    if (auto r = Option<int>::Some::match_mut(v)) {
+      *rust::RefMut(r->f0) = 67;
+    }
+
+    if (auto r = Option<int>::Some::match(v)) {
+      std::cout << r->f0 << "!!" << std::endl;
+    }
+
+    if (Option<int>::Some::check(v)) {
+        std::cout << "is some" << std::endl;
+    }
+
+    std::visit(overloaded{
+        [](rust::RefMut<Option<int>::None>) {  },
+        [](rust::RefMut<Option<int>::Some> s) { *rust::RefMut(s.f0) = 1337; },
+    }, v.match_mut());
+
+    std::visit(overloaded{
+        [](rust::Ref<Option<int>::None>) { std::cout << "none" << std::endl; },
+        [](rust::Ref<Option<int>::Some> s) { std::cout << "some " << s.f0 << std::endl; },
+    }, v.match_ref());
+
+    // Test that we can use all the merged info.
+    Merged m = Merged::first();
+    if (auto r = Merged::First::match(m)) {
+        std::cout << "first: " << r->f0 << std::endl;
+    }
+    m = Merged::second();
+    if (auto r = Merged::Second::match(m)) {
+        std::cout << "second: " << r->f0 << std::endl;
+    }
+}

--- a/examples/enums/main.zng
+++ b/examples/enums/main.zng
@@ -1,0 +1,31 @@
+#convert_panic_to_exception
+
+merge "./second.zng";
+
+mod ::std {
+    type option::Option<i32> {
+        #layout(size = 8, align = 4);
+        wellknown_traits(Debug, Copy);
+
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = i32);
+        }
+    }
+}
+
+mod crate {
+    // Primarily here to test that merging works properly.
+    type Merged {
+        // This file knows that First is non_exhaustive, but not its fields.
+        variant First {
+            non_exhaustive;
+        }
+        // And knows that Second has a 0 field, but not that it's non_exhaustive.
+        variant Second {
+            field 0 (offset = auto, type = i32);
+        }
+
+        fn first() -> Merged;
+    }
+}

--- a/examples/enums/second.zng
+++ b/examples/enums/second.zng
@@ -1,0 +1,17 @@
+mod crate {
+    type Merged {
+        #layout(size = 12, align = 4);
+        // This file knows that the whole enum is non_exhaustive.
+        non_exhaustive;
+        // That First variant has a field.
+        variant First {
+            field 0 (offset = auto, type = i32);
+        }
+        // And that the Second variant is non_exhaustive.
+        variant Second {
+            non_exhaustive;
+        }
+
+        fn second() -> Merged;
+    }
+}

--- a/examples/enums/src/lib.rs
+++ b/examples/enums/src/lib.rs
@@ -1,0 +1,18 @@
+#[rustfmt::skip]
+mod generated;
+
+pub enum Merged {
+    First(i32, i32),
+    Second(i32, i32),
+    Third,
+}
+
+impl Merged {
+    pub fn first() -> Self {
+        Self::First(42, 24)
+    }
+
+    pub fn second() -> Self {
+        Self::Second(24, 42)
+    }
+}

--- a/examples/impl_trait/NMakefile
+++ b/examples/impl_trait/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = impl_trait

--- a/examples/memory_management/NMakefile
+++ b/examples/memory_management/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = memory_management

--- a/examples/memory_management/main.cpp
+++ b/examples/memory_management/main.cpp
@@ -119,10 +119,10 @@ int main() {
   }
   std::cout << "Checkpoint 35" << std::endl;
   {
-    auto p1 = Option<PrintOnDrop>::Some(
+    Option<PrintOnDrop> p1 = Option<PrintOnDrop>::Some(
         PrintOnDrop("option_A"_rs));
     std::cout << "Checkpoint 36" << std::endl;
-    auto p2 = Option<PrintOnDrop>::Some(
+    Option<PrintOnDrop> p2 = Option<PrintOnDrop>::Some(
         PrintOnDrop("option_B"_rs));
     std::cout << "Checkpoint 37" << std::endl;
     p2.take();
@@ -135,7 +135,7 @@ int main() {
     rust::Ref<rust::Str> elems[3] = {"elem1"_rs, "elem2"_rs, "elem3"_rs};
     int i = 0;
     auto iter = rust::std::iter::from_fn(
-        rust::Box<rust::Dyn<rust::Fn<Option<PrintOnDrop>>>>::make_box([&] {
+        rust::Box<rust::Dyn<rust::Fn<Option<PrintOnDrop>>>>::make_box([&]() -> Option<PrintOnDrop> {
           if (i == 3) {
             return Option<PrintOnDrop>::None();
           }

--- a/examples/memory_management/main.zng
+++ b/examples/memory_management/main.zng
@@ -71,8 +71,10 @@ mod ::std {
         type Option<crate::PrintOnDrop> {
             #layout(size = 16, align = 8);
 
-            constructor Some(crate::PrintOnDrop);
-            constructor None;
+            variant None {}
+            variant Some {
+                field 0 (offset = auto, type = crate::PrintOnDrop);
+            }
 
             fn take(&mut self) -> Option<crate::PrintOnDrop>;
         }

--- a/examples/multiple_modules/main.cpp
+++ b/examples/multiple_modules/main.cpp
@@ -6,9 +6,9 @@
 #include <receiver.zng.h>
 
 int main() {
-  auto processor = rust::std::option::Option<rust::processor::Processor>::Some(
+  rust::std::option::Option<rust::processor::Processor> processor = rust::std::option::Option<rust::processor::Processor>::Some(
       rust::processor::Processor::new_());
-  auto receiver = rust::std::option::Option<rust::receiver::Receiver>::Some(
+  rust::std::option::Option<rust::receiver::Receiver> receiver = rust::std::option::Option<rust::receiver::Receiver>::Some(
       rust::receiver::Receiver::new_());
   auto stats =
       rust::Impl<rust::aggregation::StatsAccumulator, rust::Inherent>::create();

--- a/examples/multiple_modules/processor/processor.zng
+++ b/examples/multiple_modules/processor/processor.zng
@@ -12,7 +12,9 @@ type crate::Processor {
 type ::std::option::Option<crate::Processor> {
     #layout(size = 1, align = 1);
 
-    constructor None;
-    constructor Some(crate::Processor);
-    fn unwrap(self) -> crate::Processor;   
+    variant None {}
+    variant Some {
+        field 0 (offset = auto, type = crate::Processor);
+    }
+    fn unwrap(self) -> crate::Processor;
 }

--- a/examples/multiple_modules/receiver/receiver.zng
+++ b/examples/multiple_modules/receiver/receiver.zng
@@ -11,7 +11,9 @@ type crate::Receiver {
 type ::std::option::Option<crate::Receiver> {
     #layout(size = 16, align = 8);
 
-    constructor None;
-    constructor Some(crate::Receiver);
-    fn unwrap(self) -> crate::Receiver;   
+    variant None {}
+    variant Some {
+        field 0 (offset = auto, type = crate::Receiver);
+    }
+    fn unwrap(self) -> crate::Receiver;
 }

--- a/examples/overloaded_trait/main.cpp
+++ b/examples/overloaded_trait/main.cpp
@@ -7,7 +7,7 @@ int main() {
 
   auto ipv4 = rust::std::net::Ipv4Addr::from_bits(0);
   auto ipv6 = rust::std::net::Ipv6Addr::new_(0, 0, 0, 0, 0, 0, 0, 0);
-  auto ip = rust::std::net::IpAddr::V6(ipv6);
+  rust::std::net::IpAddr ip = rust::std::net::IpAddr::V6(ipv6);
 
   zngur_dbg(ip.partial_cmp(ipv4));
   zngur_dbg(ip.partial_cmp(ipv6));

--- a/examples/overloaded_trait/main.zng
+++ b/examples/overloaded_trait/main.zng
@@ -30,8 +30,12 @@ mod ::std::net {
         #layout(size = 17, align = 1);
         wellknown_traits(Debug, Copy);
 
-        constructor V4 (Ipv4Addr);
-        constructor V6 (Ipv6Addr);
+        variant V4 {
+            field 0 (offset = auto, type = Ipv4Addr);
+        }
+        variant V6 {
+            field 0 (offset = auto, type = Ipv6Addr);
+        }
 
         fn partial_cmp(&self, &Ipv4Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;
         fn partial_cmp(&self, &Ipv6Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;

--- a/examples/raw_pointer/NMakefile
+++ b/examples/raw_pointer/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++17 # c++17 is needed for panic to exceptions
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++17 /Zc:__cplusplus # c++17 is needed for panic to exceptions
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = raw_pointer

--- a/examples/rayon/NMakefile
+++ b/examples/rayon/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++14 # c++14 is as low as msvc goes
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++14 /Zc:__cplusplus # c++14 is as low as msvc goes
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = rayon

--- a/examples/rayon_split/NMakefile
+++ b/examples/rayon_split/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /external:I . /external:W0 /std:c++14 # c++14 is as low as msvc goes
+CXXFLAGS = /W4 /DEBUG /EHsc /external:I . /external:W0 /std:c++14 /Zc:__cplusplus # c++14 is as low as msvc goes
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = rayon_split

--- a/examples/regression_test1/NMakefile
+++ b/examples/regression_test1/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = regression_test1

--- a/examples/regression_test2/main.zng
+++ b/examples/regression_test2/main.zng
@@ -12,8 +12,8 @@ type crate::Dispatcher {
 
 type ::core::task::Poll<()> {
     #layout(size = 1, align = 1);
-    constructor Ready(());
-    constructor Pending;
+    variant Ready { non_exhaustive; }
+    variant Pending {}
 
     fn is_ready(&self) -> bool;
     fn is_pending(&self) -> bool;

--- a/examples/rustyline/NMakefile
+++ b/examples/rustyline/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib User32.lib
 
 EXAMPLE_NAME = rustyline

--- a/examples/rustyline/main.cpp
+++ b/examples/rustyline/main.cpp
@@ -14,10 +14,10 @@ int main() {
     auto r = editor.readline(">>> "_rs);
     if (r.is_err()) {
       auto e = r.unwrap_err();
-      if (e.matches_Eof()) {
+      if (rust::rustyline::error::ReadlineError::Eof::check(e)) {
         std::cout << "CTRL-D" << std::endl;
       }
-      if (e.matches_Interrupted()) {
+      if (rust::rustyline::error::ReadlineError::Interrupted::check(e)) {
         std::cout << "CTRL-C" << std::endl;
       }
       break;

--- a/examples/rustyline/main.zng
+++ b/examples/rustyline/main.zng
@@ -35,9 +35,10 @@ mod ::rustyline {
 
     type error::ReadlineError {
         #heap_allocated;
+        non_exhaustive;
 
-        constructor Interrupted;
-        constructor Eof;
+        variant Interrupted {}
+        variant Eof {}
     }
 
     type Result<DefaultEditor> {

--- a/examples/simple/NMakefile
+++ b/examples/simple/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = simple

--- a/examples/simple/expected_output.txt
+++ b/examples/simple/expected_output.txt
@@ -1,7 +1,7 @@
 17
 s[2] = 7
 
-thread panicked at examples/simple/src/generated.rs:351:40:
+thread panicked at examples/simple/src/generated.rs:375:40:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 s[4] = Rust panic happened

--- a/examples/simple/main.cpp
+++ b/examples/simple/main.cpp
@@ -23,11 +23,11 @@ public:
 
   Option<T> next() override {
     if (pos >= vec.size()) {
-      return Option<T>::None();
+      return typename Option<T>::None();
     }
     T value = vec[pos++];
     // You can construct Rust enum with fields in C++
-    return Option<T>::Some(value);
+    return typename Option<T>::Some(value);
   }
 };
 

--- a/examples/simple/main.zng
+++ b/examples/simple/main.zng
@@ -9,8 +9,10 @@ mod ::std {
         #layout(size = 8, align = 4);
         wellknown_traits(Copy);
 
-        constructor None;
-        constructor Some(i32);
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = i32);
+        }
 
         fn unwrap(self) -> i32;
     }

--- a/examples/simple_import/NMakefile
+++ b/examples/simple_import/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = simple_import

--- a/examples/simple_import/bar.zng
+++ b/examples/simple_import/bar.zng
@@ -15,8 +15,10 @@ mod ::std {
     type option::Option<::std::string::String> {
         #layout(size = 24, align = 8);
 
-        constructor None;
-        constructor Some(::std::string::String);
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = ::std::string::String);
+        }
 
         fn is_some(&self) -> bool;
         fn is_none(&self) -> bool;

--- a/examples/simple_import/expected_output.txt
+++ b/examples/simple_import/expected_output.txt
@@ -1,5 +1,5 @@
 foo(): Creating a Rust Vec<i32>
-  Vec contents: [main.cpp:13] numbers = [
+  Vec contents: [main.cpp:17] numbers = [
     10,
     20,
     30,
@@ -10,4 +10,4 @@ foo(): Creating a Rust Vec<i32>
 bar(): Creating Rust Option<String>
   some_value.is_some(): 1
   none_value.is_none(): 1
-  Unwrapped string: [main.cpp:33] unwrapped_string = ""
+  Unwrapped string: [main.cpp:37] unwrapped_string = ""

--- a/examples/simple_import/main.cpp
+++ b/examples/simple_import/main.cpp
@@ -1,9 +1,13 @@
 #include <iostream>
 #include "generated.h"
 
+template<class T> using Vec = rust::std::vec::Vec<T>;
+template<class T> using Option = rust::std::option::Option<T>;
+using String = rust::std::string::String;
+
 // External function declarations from foo.cpp and bar.cpp
-extern rust::std::vec::Vec<int32_t> foo();
-extern rust::std::option::Option<rust::std::string::String> bar();
+extern Vec<int32_t> foo();
+extern Option<String> bar();
 
 int main() {
     // Get Vec<i32> from foo() and demonstrate both imported and extended APIs
@@ -21,7 +25,7 @@ int main() {
     // Get Option<String> from bar() and demonstrate both imported and extended APIs
     std::cout << "bar(): Creating Rust Option<String>" << std::endl;
     auto some_value = bar();
-    auto none_value = rust::std::option::Option<rust::std::string::String>::None();
+    Option<String> none_value = Option<String>::None();
 
     // Use imported APIs from bar.zng
     std::cout << "  some_value.is_some(): " << some_value.is_some() << std::endl;

--- a/examples/simple_import/main.zng
+++ b/examples/simple_import/main.zng
@@ -27,9 +27,11 @@ mod ::std {
     type option::Option<::std::string::String> {
         #layout(size = 24, align = 8);
 
-        // Inherited constructors and methods from bar.zng (automatically merged)
-        constructor None;
-        constructor Some(::std::string::String);
+        // Inherited variants and methods from bar.zng (automatically merged)
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = ::std::string::String);
+        }
         fn is_some(&self) -> bool;
         fn is_none(&self) -> bool;
 

--- a/examples/template_types/expected_output.txt
+++ b/examples/template_types/expected_output.txt
@@ -9,13 +9,13 @@
         3,
     ),
 ]
-[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:20] *rust::Ref(r->f0) = TypeB(
     1,
 )
-[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:20] *rust::Ref(r->f0) = TypeB(
     2,
 )
-[main.cpp:18] vec_b.get(i).unwrap() = TypeB(
+[main.cpp:20] *rust::Ref(r->f0) = TypeB(
     3,
 )
 Hello

--- a/examples/template_types/main.cpp
+++ b/examples/template_types/main.cpp
@@ -15,7 +15,10 @@ int main() {
   vec_b.push(rust::crate::TypeB(2));
   vec_b.push(rust::crate::TypeB(3));
   for (std::size_t i = 0; i < vec_b.len(); i++) {
-    zngur_dbg(vec_b.get(i).unwrap());
+    auto opt = vec_b.get(i);
+    if (auto r = rust::std::option::Option<rust::Ref<rust::crate::TypeB>>::Some::match(opt)) {
+        zngur_dbg(*rust::Ref(r->f0));
+    }
   }
 
   auto box = rust::crate::get_box();

--- a/examples/template_types/main.zng
+++ b/examples/template_types/main.zng
@@ -9,9 +9,10 @@ type<T> [T] {
 mod ::std {
 
     type<T> option::Option<T> {
-        constructor Some(T);
-        constructor None;
-        fn unwrap(self) -> T;
+        variant None { }
+        variant Some {
+            field 0 (offset = auto, type = T);
+        }
     }
 
     type<T> option::Option<&T> {

--- a/examples/tutorial-wasm32/main.cpp
+++ b/examples/tutorial-wasm32/main.cpp
@@ -23,11 +23,11 @@ public:
 
   Option<T> next() override {
     if (pos >= vec.size()) {
-      return Option<T>::None();
+      return typename Option<T>::None();
     }
     T value = vec[pos++];
     // You can construct Rust enum with fields in C++
-    return Option<T>::Some(value);
+    return typename Option<T>::Some(value);
   }
 };
 

--- a/examples/tutorial-wasm32/main32.zng
+++ b/examples/tutorial-wasm32/main32.zng
@@ -7,8 +7,10 @@ mod ::std {
         #layout(size = 8, align = 4);
         wellknown_traits(Copy);
 
-        constructor None;
-        constructor Some(i32);
+        variant None {}
+        variant Some {
+            field 0 (offset = auto, type = i32);
+        }
 
         fn unwrap(self) -> i32;
     }

--- a/examples/tutorial/NMakefile
+++ b/examples/tutorial/NMakefile
@@ -1,5 +1,5 @@
 CXX = cl.exe
-CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
 WINLIBS = ntdll.lib
 
 EXAMPLE_NAME = tutorial

--- a/examples/tutorial_cpp/main.zng
+++ b/examples/tutorial_cpp/main.zng
@@ -36,8 +36,6 @@ type crate::Item {
 
 type ::std::fmt::Result {
     #layout(size = 1, align = 1);
-
-    constructor Ok(());
 }
 
 type ::std::fmt::Formatter {

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -53,8 +53,14 @@ pub struct ZngurExternCppImpl {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ZngurConstructor {
-    pub name: Option<String>,
     pub inputs: Vec<(String, RustType)>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ZngurVariant {
+    pub name: String,
+    pub fields: Vec<ZngurField>,
+    pub exhaustive: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -75,6 +81,7 @@ pub struct ZngurFieldData {
 pub enum ZngurFieldDataOffset {
     Offset(usize),
     Auto(String),
+    AutoDynamic(String),
 }
 
 impl ZngurFieldDataOffset {
@@ -162,8 +169,10 @@ pub struct ZngurType {
     pub ty: RustType,
     pub layout: Option<LayoutPolicy>,
     pub wellknown_traits: Vec<ZngurWellknownTrait>,
+    pub exhaustive: bool,
     pub methods: Vec<ZngurMethodDetails>,
-    pub constructors: Vec<ZngurConstructor>,
+    pub constructor: Option<ZngurConstructor>,
+    pub variants: Vec<ZngurVariant>,
     pub fields: Vec<ZngurField>,
     pub cpp_value: Option<CppValue>,
     pub cpp_ref: Option<CppRef>,

--- a/zngur-def/src/merge.rs
+++ b/zngur-def/src/merge.rs
@@ -1,7 +1,7 @@
 use crate::{
     AdditionalIncludes, ConvertPanicToException, CppRef, CppStackOwned, CppValue, LayoutPolicy,
     ZngurConstructor, ZngurExternCppFn, ZngurExternCppImpl, ZngurField, ZngurFn,
-    ZngurMethodDetails, ZngurSpec, ZngurTrait, ZngurType,
+    ZngurMethodDetails, ZngurSpec, ZngurTrait, ZngurType, ZngurVariant,
 };
 
 /// Trait for types with a partial union operation.
@@ -156,9 +156,15 @@ impl Merge for ZngurType {
         merge_by_identity(self.methods, &mut into.methods, |a, b| {
             a.data.name == b.data.name
         })?;
-        merge_by_identity(self.constructors, &mut into.constructors, |a, b| {
-            a.name == b.name
-        })?;
+        if into.constructor.is_none() {
+            into.constructor = self.constructor;
+        } else if self.constructor != into.constructor {
+            return Err(MergeFailure::Conflict(
+                "Duplicate constructor found".to_string(),
+            ));
+        }
+        into.exhaustive = self.exhaustive && into.exhaustive;
+        merge_by_identity(self.variants, &mut into.variants, |a, b| a.name == b.name)?;
         merge_by_identity(self.fields, &mut into.fields, |a, b| a.name == b.name)?;
 
         Ok(())
@@ -246,6 +252,20 @@ impl Merge for ZngurConstructor {
         if self != *into {
             return Err(MergeFailure::Conflict("Constructor mismatch".to_string()));
         }
+        Ok(())
+    }
+}
+
+impl Merge for ZngurVariant {
+    fn merge(self, into: &mut Self) -> MergeResult {
+        if self.name != into.name {
+            panic!(
+                "Attempt to merge different variants: {} and {}",
+                self.name, into.name
+            );
+        }
+        merge_by_identity(self.fields, &mut into.fields, |a, b| a.name == b.name)?;
+        into.exhaustive = self.exhaustive && into.exhaustive;
         Ok(())
     }
 }

--- a/zngur-generator/src/cpp.rs
+++ b/zngur-generator/src/cpp.rs
@@ -94,21 +94,23 @@ impl Display for CppPath {
 pub struct CppType {
     pub path: CppPath,
     pub generic_args: Vec<CppType>,
+    // TODO: is there a better way to do it?
+    pub tail: Option<String>,
 }
 
 impl CppType {
-    pub fn into_ref(self) -> CppType {
-        CppType {
-            path: CppPath::from(&*format!("{}::Ref", self.top_level_ns())),
-            generic_args: vec![self],
+    pub fn with_tail(self, tail: String) -> Self {
+        Self {
+            tail: Some(tail),
+            ..self
         }
     }
 
-    fn top_level_ns(&self) -> &String {
-        &self.path.namespace()[0]
-    }
-
     pub(crate) fn specialization_decl(&self) -> String {
+        if self.tail.is_some() {
+            panic!("specialization decl makes no sense for nested classes");
+        }
+
         let name = self.path.name();
         // Tuple<> is a little special because it is a template even though self.generic_args is empty
         if self.generic_args.is_empty() && name != "Tuple" {
@@ -120,6 +122,26 @@ impl CppType {
                 self.generic_args.iter().join(", ")
             )
         }
+    }
+
+    pub(crate) fn specialized_name(&self) -> String {
+        // We don't get `std::fmt::from_fn()` on our MSRV.
+        struct Helper<'a>(&'a CppType);
+
+        impl Display for Helper<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0.path.name())?;
+                if !self.0.generic_args.is_empty() {
+                    write!(f, "< {} >", self.0.generic_args.iter().join(", "))?;
+                }
+                if let Some(tail) = &self.0.tail {
+                    write!(f, " :: {tail}")?;
+                }
+                Ok(())
+            }
+        }
+
+        Helper(self).to_string()
     }
 
     fn header_helper(&self, state: &mut impl Write) -> std::fmt::Result {
@@ -207,12 +229,14 @@ impl From<&str> for CppType {
             None => CppType {
                 path: CppPath::from(value),
                 generic_args: vec![],
+                tail: None,
             },
             Some((path, generics)) => {
                 let generics = generics.strip_suffix('>').unwrap();
                 CppType {
                     path: CppPath::from(path),
                     generic_args: split_string(generics).map(|x| CppType::from(&*x)).collect(),
+                    tail: None,
                 }
             }
         }
@@ -347,6 +371,14 @@ impl CppMethod {
             .map(|(n, ty)| format!("{ty} i{n}"))
             .join(", ")
     }
+}
+
+#[derive(Debug)]
+pub struct CppVariant {
+    pub name: String,
+    pub constructor: Option<CppFnSig>,
+    pub match_check: String,
+    pub fields: Vec<ZngurFieldData>,
 }
 
 #[derive(Debug)]
@@ -486,7 +518,9 @@ pub struct CppTypeDefinition {
     pub ty: CppType,
     pub layout: CppLayoutPolicy,
     pub methods: Vec<CppMethod>,
-    pub constructors: Vec<CppFnSig>,
+    pub constructor: Option<CppFnSig>,
+    pub variants: Vec<CppVariant>,
+    pub discriminant: Option<String>,
     pub fields: Vec<ZngurFieldData>,
     pub from_trait: Option<RustTrait>,
     pub from_trait_ref: Option<RustTrait>,
@@ -618,7 +652,9 @@ impl Default for CppTypeDefinition {
             ty: CppType::from("fill::me::you::forgot::it"),
             layout: CppLayoutPolicy::OnlyByRef,
             methods: vec![],
-            constructors: vec![],
+            constructor: None,
+            variants: vec![],
+            discriminant: None,
             fields: vec![],
             wellknown_traits: vec![],
             from_trait: None,

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -6,8 +6,8 @@ use cpp::CppFnSig;
 use cpp::CppMethod;
 use cpp::CppPath;
 use cpp::CppTraitDefinition;
-use cpp::CppType;
 use cpp::CppTypeDefinition;
+use cpp::CppVariant;
 use cpp::cpp_handle_keyword;
 use indexmap::map::Entry;
 use itertools::Itertools;
@@ -177,54 +177,68 @@ impl ZngurGenerator {
                 ));
             }
             let mut cpp_methods = vec![];
-            let mut constructors = vec![];
+            let mut constructor = None;
+            let mut variants = vec![];
             let mut fields = vec![];
             let mut wellknown_traits = vec![];
-            for constructor in ty_def.constructors {
-                match constructor.name {
-                    Some(name) => {
-                        let rust_link_names = rust_file
-                            .add_constructor(&format!("{}::{}", ty, name), &constructor.inputs);
-                        cpp_methods.push(CppMethod {
-                            name: cpp_handle_keyword(&name).to_owned(),
-                            kind: ZngurMethodReceiver::Static,
-                            sig: CppFnSig {
-                                rust_link_name: rust_link_names.constructor,
-                                inputs: constructor
-                                    .inputs
-                                    .iter()
-                                    .map(|x| x.1.into_cpp(default_ns, &sanitized_crate_name))
-                                    .collect(),
-                                output: ty.into_cpp(default_ns, &sanitized_crate_name),
-                            },
-                        });
-                        cpp_methods.push(CppMethod {
-                            name: format!("matches_{}", name),
-                            kind: ZngurMethodReceiver::Ref(Mutability::Not),
-                            sig: CppFnSig {
-                                rust_link_name: rust_link_names.match_check,
-                                inputs: vec![
-                                    ty.into_cpp(default_ns, &sanitized_crate_name).into_ref(),
-                                ],
-                                output: CppType::from("uint8_t"),
-                            },
-                        });
-                    }
-                    None => {
-                        let rust_link_name = rust_file
-                            .add_constructor(&format!("{}", ty), &constructor.inputs)
-                            .constructor;
-                        constructors.push(CppFnSig {
-                            rust_link_name,
-                            inputs: constructor
-                                .inputs
-                                .iter()
-                                .map(|x| x.1.into_cpp(default_ns, &sanitized_crate_name))
-                                .collect(),
-                            output: ty.into_cpp(default_ns, &sanitized_crate_name),
-                        });
-                    }
+            if let Some(constructor_def) = ty_def.constructor {
+                let rust_link_name = rust_file.add_constructor(
+                    &ty.to_string(),
+                    constructor_def.inputs.iter().map(|(name, ty)| (name, ty)),
+                );
+                constructor = Some(CppFnSig {
+                    rust_link_name,
+                    inputs: constructor_def
+                        .inputs
+                        .iter()
+                        .map(|x| x.1.into_cpp(default_ns, &sanitized_crate_name))
+                        .collect(),
+                    output: ty.into_cpp(default_ns, &sanitized_crate_name),
+                });
+            }
+            let discriminant = if ty_def.exhaustive {
+                rust_file.add_discriminant(&ty.to_string(), &ty_def.variants)
+            } else {
+                None
+            };
+            for variant in ty_def.variants {
+                let rust_name = format!("{}::{}", ty, variant.name);
+                let constructor = if variant.exhaustive {
+                    let rust_link_name = rust_file.add_constructor(
+                        &rust_name,
+                        variant.fields.iter().map(|field| (&field.name, &field.ty)),
+                    );
+                    Some(CppFnSig {
+                        rust_link_name,
+                        inputs: variant
+                            .fields
+                            .iter()
+                            .map(|x| x.ty.into_cpp(default_ns, &sanitized_crate_name))
+                            .collect(),
+                        output: ty
+                            .into_cpp(default_ns, &sanitized_crate_name)
+                            .with_tail(variant.name.clone()),
+                    })
+                } else {
+                    None
+                };
+                let match_check = rust_file.add_match_check(&rust_name);
+                let mut fields = vec![];
+                for field in variant.fields {
+                    let mn =
+                        rust_file.add_variant_field_calculations(&field, &ty_def.ty, &variant.name);
+                    fields.push(ZngurFieldData {
+                        name: field.name,
+                        ty: field.ty,
+                        offset: ZngurFieldDataOffset::AutoDynamic(mn),
+                    });
                 }
+                variants.push(CppVariant {
+                    name: variant.name,
+                    constructor,
+                    match_check,
+                    fields,
+                });
             }
             for field in ty_def.fields {
                 let extern_mn = rust_file.add_field_assertions(&field, &ty_def.ty);
@@ -243,7 +257,7 @@ impl ZngurGenerator {
             if let RustType::Tuple(fields) = &ty_def.ty {
                 if !fields.is_empty() {
                     let rust_link_name = rust_file.add_tuple_constructor(&fields);
-                    constructors.push(CppFnSig {
+                    constructor = Some(CppFnSig {
                         rust_link_name,
                         inputs: fields
                             .iter()
@@ -294,7 +308,9 @@ impl ZngurGenerator {
             cpp_file.type_defs.push(CppTypeDefinition {
                 ty: ty.into_cpp(default_ns, &sanitized_crate_name),
                 layout: rust_file.add_layout_policy_shim(&ty, layout),
-                constructors,
+                constructor,
+                variants,
+                discriminant,
                 fields,
                 methods: cpp_methods,
                 wellknown_traits,

--- a/zngur-generator/src/rust.rs
+++ b/zngur-generator/src/rust.rs
@@ -29,6 +29,7 @@ impl IntoCpp for RustPathAndGenerics {
                 .chain(named_generics)
                 .map(|x| x.into_cpp(namespace, crate_name))
                 .collect(),
+            tail: None,
         }
     }
 }
@@ -48,6 +49,7 @@ impl IntoCpp for RustTrait {
                     .chain(Some(&**output))
                     .map(|x| x.into_cpp(namespace, crate_name))
                     .collect(),
+                tail: None,
             },
         }
     }
@@ -96,6 +98,7 @@ impl IntoCpp for RustType {
             RustType::Boxed(t) => CppType {
                 path: CppPath::from(&*format!("{namespace}::Box")),
                 generic_args: vec![t.into_cpp(namespace, crate_name)],
+                tail: None,
             },
             RustType::Ref(m, t) => CppType {
                 path: match m {
@@ -103,10 +106,12 @@ impl IntoCpp for RustType {
                     Mutability::Not => CppPath::from(&*format!("{}::Ref", namespace)),
                 },
                 generic_args: vec![t.into_cpp(namespace, crate_name)],
+                tail: None,
             },
             RustType::Slice(s) => CppType {
                 path: CppPath::from(&*format!("{namespace}::Slice")),
                 generic_args: vec![s.into_cpp(namespace, crate_name)],
+                tail: None,
             },
             RustType::Raw(m, t) => CppType {
                 path: match m {
@@ -114,6 +119,7 @@ impl IntoCpp for RustType {
                     Mutability::Not => CppPath::from(&*format!("{namespace}::Raw")),
                 },
                 generic_args: vec![t.into_cpp(namespace, crate_name)],
+                tail: None,
             },
             RustType::Adt(pg) => pg.into_cpp(namespace, crate_name),
             RustType::Tuple(v) => {
@@ -126,6 +132,7 @@ impl IntoCpp for RustType {
                         .into_iter()
                         .map(|x| x.into_cpp(namespace, crate_name))
                         .collect(),
+                    tail: None,
                 }
             }
             RustType::Dyn(tr, marker_bounds) => {
@@ -140,6 +147,7 @@ impl IntoCpp for RustType {
                                 .map(|x| CppType::from(&*format!("{namespace}::{x}"))),
                         )
                         .collect(),
+                    tail: None,
                 }
             }
             RustType::Impl(_, _) => panic!("impl Trait is invalid in C++"),
@@ -423,11 +431,6 @@ fn mangle_name(name: &str, mangling_base: &str) -> String {
         w!(name, "{}{pos}", which.2);
     }
     name
-}
-
-pub struct ConstructorMangledNames {
-    pub constructor: String,
-    pub match_check: String,
 }
 
 impl RustFile {
@@ -732,13 +735,12 @@ pub extern "C" fn {constructor}("#
         constructor
     }
 
-    pub fn add_constructor(
+    pub fn add_constructor<'a>(
         &mut self,
         rust_name: &str,
-        args: &[(String, RustType)],
-    ) -> ConstructorMangledNames {
+        args: impl IntoIterator<Item = (&'a String, &'a RustType)> + Clone,
+    ) -> String {
         let constructor = self.mangle_name(rust_name);
-        let match_check = format!("{constructor}_check");
         w!(
             self,
             r#"
@@ -746,7 +748,7 @@ pub extern "C" fn {constructor}("#
 #[unsafe(no_mangle)]
 pub extern "C" fn {constructor}("#
         );
-        for (name, _) in args {
+        for (name, _) in args.clone() {
             w!(self, "f_{name}: *mut u8, ");
         }
         w!(
@@ -758,6 +760,11 @@ pub extern "C" fn {constructor}("#
             w!(self, "{name}: ::std::ptr::read(f_{name} as *mut {ty}), ");
         }
         wln!(self, "}}) }} }}");
+        constructor
+    }
+
+    pub(crate) fn add_match_check(&mut self, rust_name: &str) -> String {
+        let match_check = self.mangle_name(&format!("{rust_name}_check"));
         w!(
             self,
             r#"
@@ -767,10 +774,44 @@ pub extern "C" fn {match_check}(i: *mut u8, o: *mut u8) {{ unsafe {{
     *o = matches!(&*(i as *mut &_), {rust_name} {{ .. }}) as u8;
 }} }}"#
         );
-        ConstructorMangledNames {
-            constructor,
-            match_check,
+        match_check
+    }
+
+    pub(crate) fn add_discriminant(
+        &mut self,
+        rust_name: &str,
+        variants: &[ZngurVariant],
+    ) -> Option<String> {
+        if variants.is_empty() {
+            return None;
         }
+
+        let name = self.mangle_name(&format!("{rust_name}::match"));
+        w!(
+            self,
+            r#"
+#[allow(non_snake_case)]
+#[unsafe(no_mangle)]
+pub extern "C" fn {name}(i: *mut u8) -> u32 {{ unsafe {{
+    match &*(i as *mut {rust_name} as *const _) {{"#
+        );
+        for (n, variant) in variants.iter().enumerate() {
+            let name = &variant.name;
+            w!(
+                self,
+                r#"
+        {rust_name}::{name} {{ .. }} => {n},
+        "#
+            );
+        }
+        w!(
+            self,
+            r#"
+    }}
+}} }}
+            "#
+        );
+        Some(name)
     }
 
     pub(crate) fn add_field_assertions(
@@ -798,6 +839,37 @@ pub static {mn}: usize = ::std::mem::offset_of!({owner}, {name});
             );
             Some(mn)
         }
+    }
+
+    pub(crate) fn add_variant_field_calculations(
+        &mut self,
+        field: &ZngurField,
+        owner: &RustType,
+        variant: &str,
+    ) -> String {
+        let ZngurField { name, .. } = field;
+        let mn = self.mangle_name(&format!("{owner}_{variant}_field_{name}_offset"));
+        // SAFETY: this function is only called from the variant class methods.
+        // The only way to obtain variant classes is to match, so it is impossible
+        // to obtain an instance of variant class set to a wrong variant,
+        // so this match will always pass.
+        wln!(
+            self,
+            r#"
+#[allow(non_snake_case)]
+#[unsafe(no_mangle)]
+pub extern "C" fn {mn}(i: *const u8) -> usize {{ unsafe {{
+    let base = &*(i as *const {owner});
+    match base {{
+        {owner}::{variant} {{ {name}: f, .. }} => {{
+            (f as *const _ as usize) - (base as *const _ as usize)
+        }}
+        _ => std::hint::unreachable_unchecked(),
+    }}
+}} }}
+            "#
+        );
+        mn
     }
 
     pub fn add_extern_cpp_impl(

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -9,6 +9,10 @@
 #include <array>
 #include <iostream>
 #include <functional>
+#if __cplusplus >= 201703L
+#include <variant>
+#include <optional>
+#endif
 #include <math.h>
 #include <type_traits>
 
@@ -44,14 +48,35 @@ extern "C" {
       ) noexcept ;
     {% endfor %}
 
-    {% for constructor in td.constructors %}
+    {% if let Some(constructor) = td.constructor %}
       void {{ constructor.rust_link_name }} (
         {% for n in 0..constructor.inputs.len() %}
           uint8_t*,
         {% endfor %}
         uint8_t* o
       ) noexcept ;
+    {% endif %}
+
+    {% for variant in td.variants %}
+      {% if let Some(constructor) = variant.constructor %}
+        void {{ constructor.rust_link_name }} (
+          {% for n in 0..constructor.inputs.len() %}
+            uint8_t*,
+          {% endfor %}
+          uint8_t* o
+        ) noexcept ;
+      {% endif %}
+      void {{ variant.match_check }} (uint8_t* i, uint8_t* o) noexcept;
+      {% for field in variant.fields %}
+        {% if let ZngurFieldDataOffset::AutoDynamic(field_offset_getter_name) = field.offset %}
+        size_t {{ field_offset_getter_name }}(const uint8_t* p) noexcept;
+        {% endif %}
+      {% endfor %}
     {% endfor %}
+
+    {% if let Some(discriminant) = td.discriminant %}
+      uint32_t {{ discriminant }} (uint8_t* i) noexcept;
+    {% endif %}
 
     {% if let Some(cpp_value) = td.cpp_value %}
       ::{{ self.namespace }}::ZngurCppOpaqueOwnedObject* {{ cpp_value.0 }}(uint8_t*);
@@ -199,6 +224,11 @@ namespace {{ self.namespace }} {
   {{ td.ty.path.open_namespace() }}
     {{ td.ty.specialization_decl() }} {
       public:
+
+      {% for variant in td.variants %}
+      class {{ variant.name }};
+      {% endfor %}
+
     {% if td.layout.is_only_by_ref() %}
         {{ name }}() = delete;
 
@@ -394,13 +424,79 @@ namespace {{ self.namespace }} {
         {% endif %}
     {% endfor %}
 
-    {% for constructor in td.constructors %}
+    {% if let Some(constructor) = td.constructor %}
       {{ td.ty.path.0.last().unwrap() }}(
         {{ splat!(&constructor.inputs, |n, ty|, "{ty}") }}
       ) noexcept ;
+    {% endif %}
+
+#if __cplusplus >= 201703L
+    {% if let Some(discriminant) = td.discriminant %}
+      inline ::std::variant<
+      {% for variant in td.variants %}
+        {{ name }}::{{ variant.name }}{% if !loop.last %},{% endif %}
+      {% endfor %}
+      > match() & noexcept;
+
+      inline ::std::variant<
+      {% for variant in td.variants %}
+        rust::Ref<{{ name }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+      {% endfor %}
+      > match_ref() & noexcept;
+
+      inline ::std::variant<
+      {% for variant in td.variants %}
+        rust::RefMut<{{ name }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+      {% endfor %}
+      > match_mut() & noexcept;
+    {% endif %}
+#endif
+
+    {% for variant in td.variants %}
+      inline {{ td.ty.path.0.last().unwrap() }}({{ variant.name }}&& child) noexcept;
     {% endfor %}
 
   }; // {{ td.ty.specialization_decl() }}
+
+  {% for variant in td.variants %}
+    class {{ td.ty.specialized_name() }}::{{ variant.name }} {
+    public:
+      union {
+        {{ td.ty.specialized_name() }} __zngur_parent;
+        {% for (index, field) in variant.fields.iter().enumerate() %}
+          ::{{ self.namespace }}::FieldOwned<
+            {{ field.ty.into_cpp(self.namespace, self.crate_name) }},
+            ::{{ self.namespace }}::FieldAutoOffset< {{ td.ty }}::{{ variant.name }}, {{ index }} >
+          > {{ self.cpp_handle_field_name(field.name) }};
+        {% endfor %}
+      };
+
+      inline {{ variant.name }}(
+        ::{{ self.namespace }}::__zngur_internal_unsafe_enum_constructor,
+        {{ td.ty.specialized_name() }}&& parent
+      ) noexcept: __zngur_parent(::std::move(parent)) {}
+
+      inline ~{{ variant.name }}() { ::{{ self.namespace }}::__zng_destroy_at(&__zngur_parent); }
+
+#if __cplusplus >= 201703L
+      inline static ::std::optional<{{ variant.name }}> match({{ td.ty.specialized_name() }}& parent);
+      inline static ::std::optional<rust::Ref<{{ variant.name }}>> match_ref(rust::Ref<{{ td.ty.specialized_name() }}> parent);
+      inline static ::std::optional<rust::RefMut<{{ variant.name }}>> match_mut(rust::RefMut<{{ td.ty.specialized_name() }}> parent);
+#endif
+
+      {% if let Some(c) = variant.constructor.as_ref() %}
+        inline {{ variant.name }}({{ splat!(&c.inputs, |n, ty|, "{ty} i{n}") }}) noexcept ;
+      {% endif %}
+      inline static bool check(Ref<{{ name }}>) noexcept;
+
+      {% if td.has_copy() %}
+        {{ variant.name }}(const {{ variant.name }}& other) : __zngur_parent (other.__zngur_parent) {}
+        {{ variant.name }}& operator=(const {{ variant.name }}& other) { __zngur_parent = other.__zngur_parent; return *this; }
+      {% endif %}
+      {{ variant.name }}({{ variant.name }}&& other) : __zngur_parent (::std::move(other.__zngur_parent)) {}
+      {{ variant.name }}& operator=({{ variant.name }}&& other) { __zngur_parent = ::std::move(other.__zngur_parent); return *this; }
+    };
+  {% endfor %}
 
 {{ td.ty.path.close_namespace() }}
 
@@ -455,11 +551,24 @@ namespace {{ self.namespace }} {
 
 {% endif %}
 
+{% for variant in td.variants.iter() %}
+  {% for (index, field) in variant.fields.iter().enumerate() %}
+    {% if let ZngurFieldDataOffset::AutoDynamic(field_offset_getter_name) = field.offset %}
+      template<>
+      struct FieldAutoOffset< {{ td.ty }}::{{ variant.name }}, {{ index }} > {
+        static size_t offset(const uint8_t* parent) noexcept {
+          return {{ field_offset_getter_name }}(parent);
+        }
+      };
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+
 {% for (index, field) in td.fields.iter().enumerate() %}
   {% if let ZngurFieldDataOffset::Auto(field_offset_const_name) = field.offset %}
   template <>
   struct FieldAutoOffset< {{ td.ty }}, {{ index }} > {
-    static constexpr size_t offset() noexcept { return {{ field_offset_const_name }}; }
+    static constexpr size_t offset(const uint8_t*) noexcept { return {{ field_offset_const_name }}; }
   };
   {% endif %}
 {% endfor %}
@@ -467,6 +576,34 @@ namespace {{ self.namespace }} {
 } // namespace {{ self.namespace }}
 
 namespace {{ self.namespace }} {
+
+  {% for variant in td.variants %}
+  template<>
+  struct RefMut< {{ td.ty }}::{{ variant.name }}> {
+  public:
+    RefMut() : __zngur_data(0) { }
+    RefMut({{ self.namespace }}::__zngur_internal_unsafe_enum_constructor, size_t p) : __zngur_data(p) {}
+    union {
+      size_t __zngur_data;
+
+      {% if !td.layout.is_only_by_ref() %}
+      {% for (index, field) in variant.fields.iter().enumerate() %}
+        ::{{ self.namespace }}::FieldRefMut<
+          {{ field.ty.into_cpp(self.namespace, self.crate_name) }},
+          ::{{ self.namespace }}::FieldAutoOffset< {{ td.ty }}::{{ variant.name }}, {{ index }} >
+        > {{ self.cpp_handle_field_name(field.name) }};
+      {% endfor %}
+      {% endif %}
+    };
+
+    {% if !td.layout.is_only_by_ref() %}
+    RefMut({{ td.ty }}::{{ variant.name }}& t) {
+      ::{{ self.namespace }}::__zngur_internal_check_init<{{ td.ty }}>(t.__zngur_parent);
+      __zngur_data = reinterpret_cast<size_t>(__zngur_internal_data_ptr(t.__zngur_parent));
+    }
+    {% endif %}
+  };
+  {% endfor %}
 
   template<>
   struct RefMut< {{ td.ty }} > {
@@ -510,7 +647,7 @@ namespace {{ self.namespace }} {
               bool>::type = true>
       RefMut(const FieldOwned< {{ td.ty }}, Offset, Offsets... >& f) {
           constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
           if (heap_allocated) {
             __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
           } else {
@@ -529,7 +666,7 @@ namespace {{ self.namespace }} {
               bool>::type = true>
       RefMut(const FieldOwned< {{ td.ty }}, Offset, Offsets... >& f) {
           constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
           if (heap_allocated) {
             __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
           } else {
@@ -547,7 +684,7 @@ namespace {{ self.namespace }} {
               zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       RefMut(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
 
@@ -560,7 +697,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       RefMut(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
     {% endif %}
@@ -594,6 +731,16 @@ namespace {{ self.namespace }} {
       {% endif %}
     {% endfor %}
 
+#if __cplusplus >= 201703L
+    {% if let Some(discriminant) = td.discriminant %}
+      inline ::std::variant<
+      {% for variant in td.variants %}
+        rust::RefMut<{{ td.ty }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+      {% endfor %}
+      > match_mut() noexcept;
+    {% endif %}
+#endif
+
   }; // struct RefMut< {{ td.ty }} >
 
   template<>
@@ -620,6 +767,38 @@ namespace {{ self.namespace }} {
 {% endif %}
 
 namespace {{ self.namespace }} {
+
+  {% for variant in td.variants %}
+  template<>
+  struct Ref< {{ td.ty }}::{{ variant.name }}> {
+  public:
+    Ref() : __zngur_data(0) { }
+    Ref({{ self.namespace }}::__zngur_internal_unsafe_enum_constructor, size_t p) : __zngur_data(p) {}
+    union {
+      size_t __zngur_data;
+
+      {% if !td.layout.is_only_by_ref() %}
+      {% for (index, field) in variant.fields.iter().enumerate() %}
+        ::{{ self.namespace }}::FieldRef<
+          {{ field.ty.into_cpp(self.namespace, self.crate_name) }},
+          ::{{ self.namespace }}::FieldAutoOffset< {{ td.ty }}::{{ variant.name }}, {{ index }} >
+        > {{ self.cpp_handle_field_name(field.name) }};
+      {% endfor %}
+      {% endif %}
+    };
+
+    {% if !td.layout.is_only_by_ref() %}
+    Ref(const {{ td.ty }}::{{ variant.name }}& t) {
+      ::{{ self.namespace }}::__zngur_internal_check_init<{{ td.ty }}>(t.__zngur_parent);
+      __zngur_data = reinterpret_cast<size_t>(__zngur_internal_data_ptr(t.__zngur_parent));
+    }
+    {% endif %}
+
+    Ref(RefMut< {{ td.ty }}::{{ variant.name }} > rm) {
+      __zngur_data = rm.__zngur_data;
+    }
+  };
+  {% endfor %}
 
   template<>
   struct Ref< {{ td.ty }} > {
@@ -667,7 +846,7 @@ namespace {{ self.namespace }} {
               bool>::type = true>
       Ref(const FieldOwned< {{ td.ty }}, Offset, Offsets... >& f) {
           constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
           if (heap_allocated) {
               __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
           } else {
@@ -685,7 +864,7 @@ namespace {{ self.namespace }} {
               bool>::type = true>
       Ref(const FieldOwned< {{ td.ty }}, Offset, Offsets... >& f) {
           constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
           if (heap_allocated) {
               __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
           } else {
@@ -702,7 +881,7 @@ namespace {{ self.namespace }} {
               zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRef< {{ td.ty }}, Offset, Offsets...>& f) {
-          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
 
@@ -715,7 +894,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRef< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
 
@@ -728,7 +907,7 @@ namespace {{ self.namespace }} {
               zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
 
@@ -741,7 +920,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
     {% endif %}
@@ -777,10 +956,21 @@ namespace {{ self.namespace }} {
       {% endif %}
     {% endfor %}
 
+#if __cplusplus >= 201703L
+    {% if let Some(discriminant) = td.discriminant %}
+      inline ::std::variant<
+      {% for variant in td.variants %}
+        rust::Ref<{{ td.ty }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+      {% endfor %}
+      > match_ref() noexcept;
+    {% endif %}
+#endif
+
     {% if td.ty.path.to_string() == format!("::{}::Str", &self.namespace) %}
       friend auto ::operator""_rs(const char* input, size_t len) -> ::{{ self.namespace }}::Ref<::{{ self.namespace }}::Str>;
     {% endif %}
-};
+  }; // struct Ref< {{ td.ty }}>
+
 
 {% for ref_kind in ["Ref", "Raw", "RawMut"] %}
 
@@ -830,11 +1020,11 @@ struct __zngur_internal< {{ ref_kind }} < {{ td.ty }} > > {
 
   {% let cpp_type = td.ty.to_string() %}
   {% let name = cpp_type.strip_prefix("::").unwrap() %}
+  {% let constructor_name = name.to_owned() + "::" + td.ty.path.0.last().unwrap() %}
 
-  {% for c in td.constructors %}
-    {% let fn_name = name.to_owned() + "::" + td.ty.path.0.last().unwrap() %}
+  {% if let Some(c) = td.constructor %}
     {#  do default construction first to ensure allocation  #}
-    inline {{ fn_name }}({{ splat!(&c.inputs, |n, ty|, "{ty} i{n}") }}) noexcept : {{ fn_name }}() { 
+    inline {{ constructor_name }}({{ splat!(&c.inputs, |n, ty|, "{ty} i{n}") }}) noexcept : {{ constructor_name }}() { 
       ::{{ self.namespace }}::__zngur_internal_assume_init(*this);
       {{ c.rust_link_name }}(
         {% for n in 0..c.inputs.len() %}
@@ -846,7 +1036,144 @@ struct __zngur_internal< {{ ref_kind }} < {{ td.ty }} > > {
         ::{{ self.namespace }}::__zngur_internal_assume_deinit(i{{ n }});
       {% endfor %}
     }
+  {% endif %}
+
+  {% for variant in td.variants %}
+    inline {{ constructor_name }}({{ variant.name }}&& child) noexcept: {{ constructor_name }}() {
+      *this = ::std::move(child.__zngur_parent);
+    }
+
+    {% if let Some(c) = variant.constructor.as_ref() %}
+      inline {{ name }}::{{ variant.name }}::{{ variant.name }}({{ splat!(&c.inputs, |n, ty|, "{ty} i{n}") }}) noexcept : __zngur_parent() {
+        ::{{ self.namespace }}::__zngur_internal_assume_init(this->__zngur_parent);
+        {{ c.rust_link_name }}(
+          {% for n in 0..c.inputs.len() %}
+            ::{{ self.namespace }}::__zngur_internal_data_ptr(i{{ n }}),
+          {% endfor %}
+          ::{{ self.namespace }}::__zngur_internal_data_ptr(this->__zngur_parent)
+        );
+        {% for n in 0..c.inputs.len() %}
+          ::{{ self.namespace }}::__zngur_internal_assume_deinit(i{{ n }});
+        {% endfor %}
+      }
+    {% endif %}
+
+    inline bool {{ name }}::{{ variant.name }}::check(Ref<{{ name }}> parent) noexcept{
+      uint8_t result;
+      {{ variant.match_check }}(
+        ::{{ self.namespace }}::__zngur_internal_data_ptr(parent),
+        &result
+      );
+      return result;
+    }
+
+#if __cplusplus >= 201703L
+      inline ::std::optional<{{ name }}::{{ variant.name }}> {{ name }}::{{ variant.name }}::match(
+        {{ name }}& parent
+      ) {
+        if ({{ name }}::{{ variant.name }}::check(parent)) {
+          return {{ name }}::{{ variant.name }} {
+            ::{{ self.namespace }}::__zngur_internal_unsafe_enum_constructor{},
+            ::std::move(parent),
+          };
+        }
+        return ::std::nullopt;
+      }
+
+      inline ::std::optional<rust::Ref<{{ name }}::{{ variant.name }}>> {{ name }}::{{ variant.name }}::match_ref(
+        rust::Ref<{{ name }}> parent
+      ) {
+        if ({{ name }}::{{ variant.name }}::check(parent)) {
+          rust::Ref<{{ name }}::{{ variant.name }}> r;
+          r.__zngur_data = parent.__zngur_data;
+          return r;
+        }
+        return ::std::nullopt;
+      }
+
+      inline ::std::optional<rust::RefMut<{{ name }}::{{ variant.name }}>> {{ name }}::{{ variant.name }}::match_mut(
+        rust::RefMut<{{ name }}> parent
+      ) {
+        if ({{ name }}::{{ variant.name }}::check(parent)) {
+          rust::RefMut<{{ name }}::{{ variant.name }}> r;
+          r.__zngur_data = parent.__zngur_data;
+          return r;
+        }
+        return ::std::nullopt;
+      }
+#endif
   {% endfor %}
+
+  {% if let Some(discriminant) = td.discriminant %}
+#if __cplusplus >= 201703L
+    inline ::std::variant<
+    {% for variant in td.variants %}
+      {{ name }}::{{ variant.name }}{% if !loop.last %},{% endif %}
+    {% endfor %}
+    > {{ name }}::match() & noexcept{
+      uint32_t d = {{ discriminant }}(reinterpret_cast<uint8_t*>(&this->__zngur_data));
+      switch (d) {
+      {% for (n, variant) in td.variants.iter().enumerate() %}
+        case {{ n }}: return {{ name }}::{{ variant.name }}(
+          {{ self.namespace }}::__zngur_internal_unsafe_enum_constructor{},
+          ::std::move(*this)
+        );
+      {% endfor %}
+      }
+      ::std::abort();  // exhaustiveness check in Rust prevents us from reaching this
+    }
+
+    inline ::std::variant<
+    {% for variant in td.variants %}
+      rust::Ref<{{ td.ty }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+    {% endfor %}
+    > {{ name }}::match_ref() & noexcept{
+        return rust::Ref<{{ td.ty }}>(*this).match_ref();
+    }
+
+    inline ::std::variant<
+    {% for variant in td.variants %}
+      rust::RefMut<{{ td.ty }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+    {% endfor %}
+    > {{ name }}::match_mut() & noexcept{
+        return rust::RefMut<{{ td.ty }}>(*this).match_mut();
+    }
+
+    inline ::std::variant<
+    {% for variant in td.variants %}
+      rust::Ref<{{ td.ty }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+    {% endfor %}
+    > rust::Ref<{{ name }}>::match_ref() noexcept{
+      uint32_t d = {{ discriminant }}(reinterpret_cast<uint8_t*>(this->__zngur_data));
+      switch (d) {
+      {% for (n, variant) in td.variants.iter().enumerate() %}
+        case {{ n }}: return rust::Ref<{{ name }}::{{ variant.name }}>(
+          {{ self.namespace }}::__zngur_internal_unsafe_enum_constructor{},
+          this->__zngur_data
+        );
+      {% endfor %}
+      }
+      ::std::abort();  // exhaustiveness check in Rust prevents us from reaching this
+    }
+
+    inline ::std::variant<
+    {% for variant in td.variants %}
+      rust::RefMut<{{ td.ty }}::{{ variant.name }}>{% if !loop.last %},{% endif %}
+    {% endfor %}
+    > rust::RefMut<{{ name }}>::match_mut() noexcept{
+      uint32_t d = {{ discriminant }}(reinterpret_cast<uint8_t*>(this->__zngur_data));
+      switch (d) {
+      {% for (n, variant) in td.variants.iter().enumerate() %}
+        case {{ n }}: return rust::RefMut<{{ name }}::{{ variant.name }}>(
+          {{ self.namespace }}::__zngur_internal_unsafe_enum_constructor{},
+          this->__zngur_data
+        );
+      {% endfor %}
+      }
+      ::std::abort();  // exhaustiveness check in Rust prevents us from reaching this
+    }
+#endif
+  {% endif %}
 
   {{ self.render_from_trait(td) }}
   {{ self.render_from_trait_ref(td) }}

--- a/zngur-generator/templates/zng_header.sptl
+++ b/zngur-generator/templates/zng_header.sptl
@@ -59,11 +59,16 @@ namespace {{ self.cpp_namespace }} {
 
   inline void* __zng_memcpy( void* dest, const void* src, ::std::size_t count ){
     if (count > 0) {
-		return memcpy(dest, src, count);
-	}
-	return dest;
+      return memcpy(dest, src, count);
+    }
+    return dest;
   }
 
+  // Polyfill for C++20.
+  template<typename T, typename ::std::enable_if<!::std::is_array<T>::value, bool>::type = true>
+  void __zng_destroy_at(T* p) {
+    p->~T();
+  }
 
   template<typename T>
   struct __zngur_internal {
@@ -113,6 +118,8 @@ namespace {{ self.cpp_namespace }} {
     __zngur_internal<T>::check_init(t);
   }
 
+  struct __zngur_internal_unsafe_enum_constructor {};
+
   class ZngurCppOpaqueOwnedObject {
     uint8_t* __zngur_data;
     void (*destructor)(uint8_t*);
@@ -149,7 +156,7 @@ namespace {{ self.cpp_namespace }} {
   // specialized per type to acquire offset from `extern const size_t`
   template <typename Parent, size_t INDEX>
   struct FieldAutoOffset {
-      static size_t offset() noexcept;
+      static size_t offset(const uint8_t*) noexcept;
   };
 
   // specialize to record allocation strategy into type system
@@ -192,21 +199,21 @@ namespace {{ self.cpp_namespace }} {
   template <typename T>
   struct __zngur_internal_field {
       // offset for this type and offset
-      static constexpr size_t offset();
+      static constexpr size_t offset(const uint8_t*);
       // is this offset behind a pointer
       static constexpr bool heap_allocated();
   };
 
   template <typename Parent, size_t OFFSET>
   struct __zngur_internal_field<FieldStaticOffset<Parent, OFFSET>> {
-      static constexpr size_t offset() { return OFFSET; }
+      static constexpr size_t offset(const uint8_t*) { return OFFSET; }
       static constexpr bool heap_allocated() { return zngur_heap_allocated<Parent>::value; }
   };
 
   template <typename Parent, size_t INDEX>
   struct __zngur_internal_field<FieldAutoOffset<Parent, INDEX>> {
-      static size_t offset() {
-          return FieldAutoOffset<Parent, INDEX>::offset();
+      static size_t offset(const uint8_t* parent) {
+          return FieldAutoOffset<Parent, INDEX>::offset(parent);
       }
       static constexpr bool heap_allocated() { return zngur_heap_allocated<Parent>::value; }
   };
@@ -217,7 +224,7 @@ namespace {{ self.cpp_namespace }} {
   template <typename... Offsets>
   struct __zngur_internal_calc_field {
       // used to statically calculate a total offset
-      static constexpr size_t offset();
+      static constexpr size_t offset(const uint8_t*);
       // used to check if the owner of the first offset is heap allocated
       static constexpr bool heap_allocated();
   };
@@ -225,8 +232,8 @@ namespace {{ self.cpp_namespace }} {
   // base case
   template <typename Offset>
   struct __zngur_internal_calc_field<Offset> {
-      static constexpr size_t offset() {
-          return __zngur_internal_field<Offset>::offset();
+      static constexpr size_t offset(const uint8_t* parent) {
+          return __zngur_internal_field<Offset>::offset(parent);
       }
       static constexpr bool heap_allocated() {
           return __zngur_internal_field<Offset>::heap_allocated();
@@ -236,9 +243,9 @@ namespace {{ self.cpp_namespace }} {
   // recursively calculate offsets for Fields
   template <typename LastOffset, typename PrevOffset, typename... Offsets>
   struct __zngur_internal_calc_field<LastOffset, PrevOffset, Offsets...> {
-      static constexpr size_t offset() {
-          return __zngur_internal_calc_field<PrevOffset, Offsets...>::offset() +
-                __zngur_internal_field<LastOffset>::offset();
+      static constexpr size_t offset(const uint8_t* parent) {
+          return __zngur_internal_calc_field<PrevOffset, Offsets...>::offset(parent) +
+                __zngur_internal_field<LastOffset>::offset(parent);
       }
       static constexpr bool heap_allocated() {
           return __zngur_internal_calc_field<PrevOffset, Offsets...>::heap_allocated();
@@ -425,25 +432,25 @@ namespace {{ self.cpp_namespace }} {
     template <typename Offset, typename... Offsets, typename ::std::enable_if<zngur_detail::is_static_offset<Offset, Offsets...>::value, bool>::type = true>
     RefMut(const FieldOwned< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets... >& f) {
         constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
         if (heap_allocated) { __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset; }
         else { __zngur_data = reinterpret_cast<size_t>(&f) + offset; }
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::is_static_offset<Offset, Offsets...>::value, bool>::type = true>
     RefMut(const FieldOwned< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets... >& f) {
         constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
         if (heap_allocated) { __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset; }
         else { __zngur_data = reinterpret_cast<size_t>(&f) + offset; }
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     RefMut(const FieldRefMut< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     RefMut(const FieldRefMut< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
   };
@@ -471,35 +478,35 @@ namespace {{ self.cpp_namespace }} {
     template <typename Offset, typename... Offsets, typename ::std::enable_if<zngur_detail::is_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldOwned< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets... >& f) {
         constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
         if (heap_allocated) { __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset; }
         else { __zngur_data = reinterpret_cast<size_t>(&f) + offset; }
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::is_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldOwned< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets... >& f) {
         constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
         if (heap_allocated) { __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset; }
         else { __zngur_data = reinterpret_cast<size_t>(&f) + offset; }
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldRef< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldRef< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldRefMut< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldRefMut< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
   };
@@ -570,7 +577,7 @@ namespace {{ self.cpp_namespace }} {
             bool>::type = true>
     {{ ref_kind }}(const FieldOwned< {{ nested_ref_kind }} < T >, Offset, Offsets... >& f) {
       constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       if (heap_allocated) {
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       } else {
@@ -588,7 +595,7 @@ namespace {{ self.cpp_namespace }} {
             bool>::type = true>
     {{ ref_kind }}(const FieldOwned< {{ nested_ref_kind }} < T >, Offset, Offsets... >& f) {
       constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
       if (heap_allocated) {
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       } else {
@@ -606,7 +613,7 @@ namespace {{ self.cpp_namespace }} {
             zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     {{ ref_kind }}(const FieldRef< {{ nested_ref_kind }} < T >, Offset, Offsets...>& f) {
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -619,7 +626,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     {{ ref_kind }}(const FieldRef< {{ nested_ref_kind }} < T >, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     {% endif %}
@@ -633,7 +640,7 @@ namespace {{ self.cpp_namespace }} {
             zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     {{ ref_kind }}(const FieldRefMut< {{ nested_ref_kind }} < T >, Offset, Offsets...>& f) {
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -646,7 +653,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     {{ ref_kind }}(const FieldRefMut< {{ nested_ref_kind }} < T >, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -757,7 +764,7 @@ namespace {{ self.cpp_namespace }} {
             bool>::type = true>
     Ref(const FieldOwned< {{ ty }}, Offset, Offsets... >& f) {
       constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       if (heap_allocated) {
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       } else {
@@ -775,7 +782,7 @@ namespace {{ self.cpp_namespace }} {
             bool>::type = true>
     Ref(const FieldOwned< {{ ty }}, Offset, Offsets... >& f) {
       constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
       if (heap_allocated) {
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       } else {
@@ -792,7 +799,7 @@ namespace {{ self.cpp_namespace }} {
             zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     Ref(const FieldRef< {{ ty }}, Offset, Offsets...>& f) {
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -805,7 +812,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     Ref(const FieldRef< {{ ty }}, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -818,7 +825,7 @@ namespace {{ self.cpp_namespace }} {
             zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     Ref(const FieldRefMut< {{ ty }}, Offset, Offsets...>& f) {
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -831,7 +838,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     Ref(const FieldRefMut< {{ ty }}, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -870,7 +877,7 @@ namespace {{ self.cpp_namespace }} {
             bool>::type = true>
     RefMut(const FieldOwned< {{ ty }}, Offset, Offsets... >& f) {
       constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       if (heap_allocated) {
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       } else {
@@ -888,7 +895,7 @@ namespace {{ self.cpp_namespace }} {
             bool>::type = true>
     RefMut(const FieldOwned< {{ ty }}, Offset, Offsets... >& f) {
       constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
       if (heap_allocated) {
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       } else {
@@ -905,7 +912,7 @@ namespace {{ self.cpp_namespace }} {
             zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     RefMut(const FieldRefMut< {{ ty }}, Offset, Offsets...>& f) {
-      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      constexpr size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(nullptr);
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -918,7 +925,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     RefMut(const FieldRefMut< {{ ty }}, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset();
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -16,7 +16,7 @@ use zngur_def::{
     LayoutPolicy, Merge, MergeFailure, ModuleImport, Mutability, PrimitiveRustType,
     RustPathAndGenerics, RustTrait, RustType, TypeVar, ZngurConstructor, ZngurExternCppFn,
     ZngurExternCppImpl, ZngurField, ZngurFn, ZngurMethod, ZngurMethodDetails, ZngurMethodReceiver,
-    ZngurSpec, ZngurTrait, ZngurType, ZngurWellknownTrait,
+    ZngurSpec, ZngurTrait, ZngurType, ZngurVariant, ZngurWellknownTrait,
 };
 
 pub type Span = SimpleSpan<usize>;
@@ -358,9 +358,13 @@ enum ParsedLayoutPolicy<'a> {
 enum ParsedTypeItem<'a> {
     Layout(Span, ParsedLayoutPolicy<'a>),
     Traits(Vec<Spanned<ZngurWellknownTrait>>),
+    NonExhaustive,
     Constructor {
-        name: Option<&'a str>,
         args: ParsedConstructorArgs<'a>,
+    },
+    Variant {
+        name: &'a str,
+        items: Vec<Spanned<ParsedTypeItem<'a>>>,
     },
     Field {
         name: String,
@@ -486,11 +490,13 @@ impl ProcessedItem<'_> {
                 };
 
                 let mut methods = vec![];
-                let mut constructors = vec![];
+                let mut constructor = None;
+                let mut variants = vec![];
                 let mut fields = vec![];
                 let mut wellknown_traits = vec![];
                 let mut layout = None;
                 let mut layout_span = None;
+                let mut exhaustive = true;
                 let mut cpp_value = None;
                 let mut cpp_ref = None;
                 let mut cpp_stack_owned = None;
@@ -560,9 +566,20 @@ impl ProcessedItem<'_> {
                         ParsedTypeItem::Traits(tr) => {
                             wellknown_traits.extend(tr);
                         }
-                        ParsedTypeItem::Constructor { name, args } => {
-                            constructors.push(ZngurConstructor {
-                                name: name.map(|x| x.to_owned()),
+                        ParsedTypeItem::NonExhaustive => {
+                            if !exhaustive {
+                                ctx.add_error_str(
+                                    "Duplicate non_exhaustive annotation found",
+                                    item_span,
+                                );
+                            }
+                            exhaustive = false;
+                        }
+                        ParsedTypeItem::Constructor { args } => {
+                            if constructor.is_some() {
+                                ctx.add_error_str("Duplicate constructor found", item_span);
+                            }
+                            constructor = Some(ZngurConstructor {
                                 inputs: match args {
                                     ParsedConstructorArgs::Unit => vec![],
                                     ParsedConstructorArgs::Tuple(t) => t
@@ -575,7 +592,43 @@ impl ProcessedItem<'_> {
                                         .map(|(i, t)| (i.to_owned(), t.to_zngur(scope)))
                                         .collect(),
                                 },
-                            })
+                            });
+                        }
+                        ParsedTypeItem::Variant { name, items } => {
+                            let mut exhaustive = true;
+                            let mut fields = vec![];
+                            for item in items {
+                                match item.inner {
+                                    ParsedTypeItem::NonExhaustive => {
+                                        if !exhaustive {
+                                            ctx.add_error_str(
+                                                "Duplicate non_exhaustive annotation found",
+                                                item.span,
+                                            );
+                                        }
+                                        exhaustive = false;
+                                    }
+                                    ParsedTypeItem::Field { name, ty, offset } => {
+                                        if offset.is_some() {
+                                            ctx.add_error_str(
+                                                "static offsets on enum fields are not supported",
+                                                item.span,
+                                            );
+                                        }
+                                        fields.push(ZngurField {
+                                            name: name.to_owned(),
+                                            ty: ty.to_zngur(scope),
+                                            offset,
+                                        });
+                                    }
+                                    _ => panic!("bug: invalid variant item found: {item:?}"),
+                                }
+                            }
+                            variants.push(ZngurVariant {
+                                name: name.to_owned(),
+                                fields,
+                                exhaustive,
+                            });
                         }
                         ParsedTypeItem::Field { name, ty, offset } => {
                             fields.push(ZngurField {
@@ -694,7 +747,9 @@ impl ProcessedItem<'_> {
                     layout,
                     methods,
                     wellknown_traits: wt,
-                    constructors,
+                    exhaustive,
+                    constructor,
+                    variants,
                     fields,
                     cpp_value,
                     cpp_ref,
@@ -1011,9 +1066,11 @@ impl<'a, 'b> ParseContext<'a, 'b> {
             )
             .unwrap();
         }
-        std::panic::resume_unwind(Box::new(tests::ErrorText(
-            String::from_utf8(strip_ansi_escapes::strip(r)).unwrap(),
-        )));
+        std::panic::resume_unwind(Box::new(tests::ErrorText({
+            let s = String::from_utf8(strip_ansi_escapes::strip(r)).unwrap();
+            eprintln!("{s}");
+            s
+        })));
     }
 
     #[cfg(not(test))]
@@ -1879,6 +1936,8 @@ fn inner_type_item<'a>()
         )
         .map(ParsedTypeItem::Traits)
         .boxed();
+    let non_exhaustive =
+        just(Token::Ident("non_exhaustive")).map(|_| ParsedTypeItem::NonExhaustive);
     let constructor_args = rust_type()
         .separated_by(just(Token::Comma))
         .collect::<Vec<_>>()
@@ -1896,14 +1955,9 @@ fn inner_type_item<'a>()
         .map(ParsedConstructorArgs::Named))
         .or(empty().to(ParsedConstructorArgs::Unit))
         .boxed();
-    let constructor = just(Token::Ident("constructor")).ignore_then(
-        (select! {
-            Token::Ident(c) => Some(c),
-        })
-        .or(empty().to(None))
-        .then(constructor_args)
-        .map(|(name, args)| ParsedTypeItem::Constructor { name, args }),
-    );
+    let constructor = just(Token::Ident("constructor"))
+        .ignore_then(constructor_args)
+        .map(|args| ParsedTypeItem::Constructor { args });
     let field = just(Token::Ident("field")).ignore_then(
         (select! {
             Token::Ident(c) => c.to_owned(),
@@ -1959,10 +2013,24 @@ fn inner_type_item<'a>()
                 .boxed(),
         )
         .map(|(cpp_type, props)| ParsedTypeItem::CppStackOwned { cpp_type, props });
+
+    let variant = just(Token::Ident("variant"))
+        .ignore_then(select! { Token::Ident(c) => c })
+        .then(
+            spanned(
+                choice((non_exhaustive.clone(), field.clone())).then_ignore(just(Token::Semicolon)),
+            )
+            .repeated()
+            .collect::<Vec<_>>()
+            .delimited_by(just(Token::BraceOpen), just(Token::BraceClose)),
+        )
+        .map(|(name, items)| ParsedTypeItem::Variant { name, items });
+
     recursive(|item| {
         let inner_item = choice((
             layout.boxed(),
             traits.boxed(),
+            non_exhaustive.boxed(),
             constructor.boxed(),
             field.boxed(),
             cpp_value.boxed(),
@@ -2006,6 +2074,7 @@ fn inner_type_item<'a>()
 
         choice((
             match_stmt,
+            variant,
             inner_item.then_ignore(just(Token::Semicolon)).boxed(),
         ))
     })

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use zngur_def::{
     Merge, RustPathAndGenerics, RustTrait, RustType, TypeVar, ZngurConstructor, ZngurField,
-    ZngurMethod, ZngurMethodDetails, ZngurType,
+    ZngurMethod, ZngurMethodDetails, ZngurType, ZngurVariant,
 };
 
 fn matches_template<'a, 'b>(
@@ -230,8 +230,10 @@ pub fn try_match_template(ty: &RustType, template: &ZngurType) -> Option<Templat
         ty: template_ty,
         layout,
         wellknown_traits,
+        exhaustive,
         methods,
-        constructors,
+        constructor,
+        variants,
         fields,
         cpp_ref,
         cpp_value,
@@ -242,44 +244,57 @@ pub fn try_match_template(ty: &RustType, template: &ZngurType) -> Option<Templat
         ty: ty.clone(),
         layout: *layout,
         wellknown_traits: wellknown_traits.clone(),
+        exhaustive: *exhaustive,
         methods: methods
             .iter()
-            .filter_map(|method| match substitute_method_vars(method, &mapping) {
-                Ok(m) => Some(m),
+            .map(|method| match substitute_method_vars(method, &mapping) {
+                Ok(m) => m,
                 Err(SubstitutionError::UnboundVar(var)) => unreachable!(
                     "Unbound type variable {} in method {} in template {} for type {}",
                     var.0, method.data.name, template.ty, ty
                 ),
             })
             .collect(),
-        constructors: constructors
-            .iter()
-            .filter_map(|constructor| {
-                match constructor
-                    .inputs
-                    .iter()
-                    .map(|(name, ty)| substitute_vars(ty, &mapping).map(|ty| (name.clone(), ty)))
-                    .collect()
-                {
-                    Ok(inputs) => Some(ZngurConstructor {
-                        name: constructor.name.clone(),
-                        inputs,
-                    }),
-                    Err(SubstitutionError::UnboundVar(var)) => unreachable!(
-                        "Unbound type variable {} in constructor {:?} in template {} for type {}",
-                        var.0, constructor.name, template.ty, ty
-                    ),
-                }
-            })
-            .collect(),
-        fields: fields
-            .iter()
-            .filter_map(|field| match substitute_vars(&field.ty, &mapping) {
-                Ok(ty) => Some(ZngurField {
+        constructor: constructor.as_ref().map(|constructor| {
+            match constructor
+                .inputs
+                .iter()
+                .map(|(name, ty)| substitute_vars(ty, &mapping).map(|ty| (name.clone(), ty)))
+                .collect()
+            {
+                Ok(inputs) => ZngurConstructor { inputs },
+                Err(SubstitutionError::UnboundVar(var)) => unreachable!(
+                    "Unbound type variable {} in constructor in template {} for type {}",
+                    var.0, template.ty, ty
+                ),
+            }
+        }),
+        variants: variants.iter().map(|variant| {
+            let fields = variant.fields.iter().map(|field| match substitute_vars(&field.ty, &mapping) {
+                Ok(ty) => ZngurField {
                     name: field.name.clone(),
                     ty,
                     offset: field.offset,
-                }),
+                },
+                Err(SubstitutionError::UnboundVar(var)) => unreachable!(
+                    "Unbound type variable {} in field {} of variant {}, in template {} for type {}",
+                    var.0, field.name, variant.name, template.ty, ty
+                ),
+            }).collect();
+            ZngurVariant {
+                name: variant.name.clone(),
+                exhaustive: variant.exhaustive,
+                fields,
+            }
+        }).collect(),
+        fields: fields
+            .iter()
+            .map(|field| match substitute_vars(&field.ty, &mapping) {
+                Ok(ty) => ZngurField {
+                    name: field.name.clone(),
+                    ty,
+                    offset: field.offset,
+                },
                 Err(SubstitutionError::UnboundVar(var)) => unreachable!(
                     "Unbound type variable {} in field {} in template {} for type {}",
                     var.0, field.name, template.ty, ty

--- a/zngur-parser/src/tests.rs
+++ b/zngur-parser/src/tests.rs
@@ -122,12 +122,12 @@ type () {
 }
     "#,
         expect![[r#"
-            Error: found 'welcome_traits' expected '#', 'wellknown_traits', 'constructor', 'field', 'async', 'fn', or '}'
+            Error: found 'welcome_traits' expected '#', 'variant', 'wellknown_traits', 'non_exhaustive', 'constructor', 'field', 'async', 'fn', or '}'
                ╭─[test.zng:4:5]
                │
              4 │     welcome_traits(Copy);
                │     ───────┬──────  
-               │            ╰──────── found 'welcome_traits' expected '#', 'wellknown_traits', 'constructor', 'field', 'async', 'fn', or '}'
+               │            ╰──────── found 'welcome_traits' expected '#', 'variant', 'wellknown_traits', 'non_exhaustive', 'constructor', 'field', 'async', 'fn', or '}'
             ───╯
         "#]],
     );
@@ -229,6 +229,39 @@ mod crate {
         panic!("no match?");
     };
     assert_eq!(p.as_slice(), ["crate", "MyLocalString"]);
+}
+
+#[test]
+fn parse_variants() {
+    println!("meow");
+
+    let parsed = ParsedZngFile::parse_str(
+        r#"
+type Option<i32> {
+    #layout(size = 8, align = 4);
+    variant None { }
+    variant Some {
+        field 0 (offset = auto, type = i32);
+    }
+}
+        "#,
+        NullCfg,
+    );
+
+    let ty = parsed.spec.types.first().expect("no type parsed");
+    assert_eq!(ty.variants.len(), 2, "should have two variants");
+
+    assert_eq!(ty.variants[0].name, "None");
+    assert_eq!(ty.variants[0].fields.len(), 0);
+
+    assert_eq!(ty.variants[1].name, "Some");
+    assert_eq!(ty.variants[1].fields.len(), 1);
+    assert_eq!(ty.variants[1].fields[0].name, "0");
+    assert_eq!(
+        ty.variants[1].fields[0].ty,
+        RustType::Primitive(zngur_def::PrimitiveRustType::Int(32))
+    );
+    assert_eq!(ty.variants[1].fields[0].offset, None);
 }
 
 struct MockFilesystem {


### PR DESCRIPTION
(imagine it’s a tracking issue for what was proposed in [this comment](https://github.com/hkalbasi/zngur/pull/125#issuecomment-4804586399) now)

- [x] parsing
- [x] testing
- [x] docs

variant classes:
- [x] match
- [x] match_ref
- [x] match_mut
- [x] check
- [x] constructor from fields
- [x] field access

enum class:
- [x] match
- [x] match_ref
- [x] match_mut
- [x] constructors from variants

<details><summary>original text</summary>

hi! currently, to use rust enums in cpp you have to manually write and bind functions that extract data from enum variants. this patch adds automatic generation of `.unwrap_Variant()` methods for the trivial case: tuple variants that only have a single field

this restriction avoids the question of how the return type should look for more complex cases: I think for tuple variants with multiple fields we should return `std::tuple`, and for struct variants we should codegen a helper struct, but in these cases there’re multiple options, and a single-field tuple variant case is straightforward. at the same time, this has a lot of utility, as this case is really common, and all the other cases can be emulated by putting a struct inside the single field

(unfortunately, this also generates an unwrap method for single-field tuple structs, as zng format does not distinguish between structs and enums. I could gate the generation on having multiple constructors though, let me know what you think)

obviously, this will also need tests and documentation, which I’m happy to write if you accept the idea in general

</details>