### PR TITLE
allow renaming of methods on the c++ side

### DIFF
--- a/book/src/call_rust_from_cpp/name_mapping.md
+++ b/book/src/call_rust_from_cpp/name_mapping.md
@@ -67,3 +67,33 @@ char* bc = (char*)&b;
 So Zngur can't use `bool` the way it uses `uint32_t` and friends.
 But it adds some special codes to `bool`
 so that you can use it in an `if` statement or cast it to and from C++ `bool`.
+
+## Renaming generated C++ wrapper functions
+
+Traits may be implemented multiple times with different parameters for the same Rust type, providing identically named methods with different type signatures.
+C++ does not support overloading functions based on their return type in this manner, but we still want to be able to expose all implementations of a trait without requiring *additional* traits just to rename methods.
+Zngur allows renaming an exposed method on the C++ side from the spec itself to support this.
+Since C++ does support overloading methods based on their argument types such renaming is only needed when method implementations differ in their return types only.
+
+```
+type ::std::string::String {
+    #layout(size = 24, align = 8);
+
+    fn as_ref(&self) -> &str use ::std::convert::AsRef;
+    // renaming needed for the second overload since only the return type differs
+    fn as_ref(&self) -> &[u8] use ::std::convert::AsRef as as_ref_u8;
+}
+
+mod ::std::net {
+    type IpAddr {
+        #layout(size = 17, align = 1);
+
+        constructor V4(Ipv4Addr);
+        constructor V6(Ipv6Addr);
+
+        fn partial_cmp(&self, &Ipv4Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;
+        // renaming not needed since the argument types differ
+        fn partial_cmp(&self, &Ipv6Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;
+    }
+}
+```

--- a/examples/overloaded_trait/.gitignore
+++ b/examples/overloaded_trait/.gitignore
@@ -1,0 +1,2 @@
+generated.h
+generated.rs

--- a/examples/overloaded_trait/Cargo.toml
+++ b/examples/overloaded_trait/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-overloaded-trait"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/overloaded_trait/Makefile
+++ b/examples/overloaded_trait/Makefile
@@ -1,0 +1,15 @@
+NAME = overloaded_trait
+
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_$(NAME).a
+	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/release/ -l example_$(NAME)
+
+../../target/release/libexample_$(NAME).a:
+	cargo build --release
+
+generated.h ./src/generated.rs: main.zng
+	cd ../../zngur-cli && cargo run g -i ../examples/$(NAME)/main.zng --crate-name "crate"
+
+.PHONY: ../../target/release/libexample_$(NAME).a generated.h clean
+
+clean:
+	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/overloaded_trait/NMakefile
+++ b/examples/overloaded_trait/NMakefile
@@ -1,0 +1,23 @@
+CXX = cl.exe
+CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
+WINLIBS = ntdll.lib
+
+EXAMPLE_NAME = overloaded_trait
+
+GENERATED = generated.h src/generated.rs
+
+RUSTLIB_PATH = ../../target/release/
+
+RUSTLIB = example_$(EXAMPLE_NAME).lib
+
+a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
+	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
+
+$(RUSTLIB_PATH)/$(RUSTLIB) :
+	cargo build --release
+
+$(GENERATED) : main.zng
+	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"
+
+clean :
+	- del /f /q generated.h generated.cpp src\generated.rs a.exe main.obj actual_output.txt 2>nul

--- a/examples/overloaded_trait/expected_output.txt
+++ b/examples/overloaded_trait/expected_output.txt
@@ -1,0 +1,15 @@
+[main.cpp:5] s.as_ref() = "string"
+[main.cpp:6] s.as_ref_u8() = [
+    115,
+    116,
+    114,
+    105,
+    110,
+    103,
+]
+[main.cpp:12] ip.partial_cmp(ipv4) = Some(
+    Greater,
+)
+[main.cpp:13] ip.partial_cmp(ipv6) = Some(
+    Equal,
+)

--- a/examples/overloaded_trait/main.cpp
+++ b/examples/overloaded_trait/main.cpp
@@ -1,0 +1,14 @@
+#include "./generated.h"
+
+int main() {
+  auto s = "string"_rs.to_owned();
+  zngur_dbg(s.as_ref());
+  zngur_dbg(s.as_ref_u8());
+
+  auto ipv4 = rust::std::net::Ipv4Addr::from_bits(0);
+  auto ipv6 = rust::std::net::Ipv6Addr::new_(0, 0, 0, 0, 0, 0, 0, 0);
+  auto ip = rust::std::net::IpAddr::V6(ipv6);
+
+  zngur_dbg(ip.partial_cmp(ipv4));
+  zngur_dbg(ip.partial_cmp(ipv6));
+}

--- a/examples/overloaded_trait/main.zng
+++ b/examples/overloaded_trait/main.zng
@@ -1,0 +1,53 @@
+type bool {
+    #layout(size = 1, align = 1);
+    wellknown_traits(Debug);
+}
+
+type str {
+    wellknown_traits(?Sized, Debug);
+
+    fn to_owned(&self) -> ::std::string::String;
+}
+
+type [u8] {
+    wellknown_traits(?Sized, Debug);
+}
+
+type ::std::string::String {
+    #layout(size = 24, align = 8);
+
+    fn as_ref(&self) -> &str use ::std::convert::AsRef;
+    fn as_ref(&self) -> &[u8] use ::std::convert::AsRef as as_ref_u8;
+}
+
+type ::std::option::Option<::std::cmp::Ordering> {
+    #layout(size = 1, align = 1);
+    wellknown_traits(Debug);
+}
+
+mod ::std::net {
+    type IpAddr {
+        #layout(size = 17, align = 1);
+        wellknown_traits(Debug, Copy);
+
+        constructor V4 (Ipv4Addr);
+        constructor V6 (Ipv6Addr);
+
+        fn partial_cmp(&self, &Ipv4Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;
+        fn partial_cmp(&self, &Ipv6Addr) -> ::std::option::Option<::std::cmp::Ordering> use ::std::cmp::PartialOrd;
+    }
+
+    type Ipv4Addr {
+        #layout(size = 4, align = 1);
+        wellknown_traits(Debug, Copy);
+
+        fn from_bits(u32) -> Ipv4Addr;
+    }
+
+    type Ipv6Addr {
+        #layout(size = 16, align = 1);
+        wellknown_traits(Debug, Copy);
+
+        fn new(u16, u16, u16, u16, u16, u16, u16, u16) -> Ipv6Addr;
+    }
+}

--- a/examples/overloaded_trait/src/lib.rs
+++ b/examples/overloaded_trait/src/lib.rs
@@ -1,0 +1,2 @@
+#[rustfmt::skip]
+mod generated;

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -135,6 +135,7 @@ pub struct ZngurMethodDetails {
     pub data: ZngurMethod,
     pub use_path: Option<Vec<String>>,
     pub deref: Option<(RustType, Mutability)>,
+    pub cpp_name: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -265,10 +265,13 @@ impl ZngurGenerator {
                     data: method,
                     use_path,
                     deref,
+                    cpp_name,
                 } = method_details;
                 let rusty_inputs = real_inputs_of_method(&method, &ty);
+                let cpp_name = cpp_name.as_ref().unwrap_or(&method.name);
 
                 let sig = rust_file.add_function(
+                    cpp_name,
                     &format!(
                         "<{}>::{}::<{}>",
                         deref.as_ref().map(|x| &x.0).unwrap_or(&ty),
@@ -283,7 +286,7 @@ impl ZngurGenerator {
                     &sanitized_crate_name,
                 );
                 cpp_methods.push(CppMethod {
-                    name: cpp_handle_keyword(&method.name).to_owned(),
+                    name: cpp_handle_keyword(cpp_name).to_owned(),
                     kind: method.receiver,
                     sig,
                 });
@@ -349,6 +352,7 @@ pub mod cpp {{
         }
         for func in zng.funcs {
             let sig = rust_file.add_function(
+                &func.path.to_string(),
                 &func.path.to_string(),
                 &func.inputs,
                 &func.output,

--- a/zngur-generator/src/rust.rs
+++ b/zngur-generator/src/rust.rs
@@ -922,6 +922,7 @@ pub extern "C" fn {mangled_name}(d: *mut u8) -> *mut cpp::{type_name} {{
 
     pub fn add_function(
         &mut self,
+        cxx_name: &str,
         rust_name: &str,
         inputs: &[RustType],
         output: &RustType,
@@ -930,7 +931,8 @@ pub extern "C" fn {mangled_name}(d: *mut u8) -> *mut cpp::{type_name} {{
         namespace: &str,
         crate_name: &str,
     ) -> CppFnSig {
-        let mut mangled_name = self.mangle_name(rust_name) + "_" + &hash_of_sig(&inputs);
+        let mut mangled_name =
+            self.mangle_name(&format!("{cxx_name}={rust_name}")) + "_" + &hash_of_sig(&inputs);
         if deref.is_some() {
             mangled_name += "_deref";
         }

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -371,6 +371,7 @@ enum ParsedTypeItem<'a> {
         data: ParsedMethod<'a>,
         use_path: Option<ParsedPath<'a>>,
         deref: Option<ParsedRustType<'a>>,
+        cpp_name: Option<&'a str>,
     },
     CppValue {
         field: &'a str,
@@ -587,6 +588,7 @@ impl ProcessedItem<'_> {
                             data,
                             use_path,
                             deref,
+                            cpp_name,
                         } => {
                             let deref = deref.and_then(|x| {
                                 let deref_type = x.to_zngur(scope);
@@ -606,6 +608,7 @@ impl ProcessedItem<'_> {
                                 data: data.to_zngur(scope),
                                 use_path: use_path.map(|x| scope.resolve_path(x)),
                                 deref,
+                                cpp_name: cpp_name.map(|s| s.to_owned()),
                             });
                         }
                         ParsedTypeItem::CppValue { field, cpp_type } => {
@@ -1951,11 +1954,19 @@ fn inner_type_item<'a>()
                         .map(Some)
                         .or(empty().to(None)),
                 )
-                .map(|((data, use_path), deref)| ParsedTypeItem::Method {
-                    deref,
-                    use_path,
-                    data,
-                }),
+                .then(
+                    just(Token::KwAs)
+                        .ignore_then(select! { Token::Ident(c) => Some(c), })
+                        .or(empty().to(None)),
+                )
+                .map(
+                    |(((data, use_path), deref), cpp_name)| ParsedTypeItem::Method {
+                        deref,
+                        use_path,
+                        data,
+                        cpp_name,
+                    },
+                ),
         ));
 
         let match_stmt =

--- a/zngur-parser/src/template_types.rs
+++ b/zngur-parser/src/template_types.rs
@@ -195,6 +195,7 @@ fn substitute_method_vars<'a>(
             },
         use_path,
         deref,
+        cpp_name,
     } = m;
     Ok(ZngurMethodDetails {
         data: ZngurMethod {
@@ -216,6 +217,7 @@ fn substitute_method_vars<'a>(
             Some((ty, mutability)) => Some((substitute_vars(&ty, mapping)?, *mutability)),
             None => None,
         },
+        cpp_name: cpp_name.clone(),
     })
 }
 


### PR DESCRIPTION
this lets us expose methods overloaded on their return type only (such as `AsRef::as_ref`) without wrapper traits on the rust side for merely renaming and reëexposing of a method. the c++ name is encoded into the rust wrapper function even when no renaming is needed for consistency; we could skip this step since the mangling will be uniqure either way, but always producing the same format of mangled name seems much nicer.