### PR TITLE
Fix incorrect reinterpret_cast in field offset calculation.

### DIFF
--- a/examples/enums/main.cpp
+++ b/examples/enums/main.cpp
@@ -9,6 +9,7 @@ template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 template<class T> using Option = rust::std::option::Option<T>;
 using Merged = rust::crate::Merged;
+using Container = rust::crate::Container;
 
 int main() {
     Option<int> v = Option<int>::Some(42);
@@ -48,4 +49,7 @@ int main() {
     if (auto r = Merged::Second::match(m)) {
         std::cout << "second: " << r->f0 << std::endl;
     }
+
+    Container c = { Merged::first() };
+    auto cr = rust::Ref(c.f0);
 }

--- a/examples/enums/main.zng
+++ b/examples/enums/main.zng
@@ -28,4 +28,10 @@ mod crate {
 
         fn first() -> Merged;
     }
+
+    type Container {
+        #layout(size = 12, align = 4);
+        field 0 (offset = auto, type = Merged);
+        constructor (Merged);
+    }
 }

--- a/examples/enums/src/lib.rs
+++ b/examples/enums/src/lib.rs
@@ -16,3 +16,6 @@ impl Merged {
         Self::Second(24, 42)
     }
 }
+
+// Test that enums behave properly inside of fields.
+pub struct Container(pub Merged);

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -666,7 +666,7 @@ namespace {{ self.namespace }} {
               bool>::type = true>
       RefMut(const FieldOwned< {{ td.ty }}, Offset, Offsets... >& f) {
           constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
           if (heap_allocated) {
             __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
           } else {
@@ -697,7 +697,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       RefMut(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
     {% endif %}
@@ -864,7 +864,7 @@ namespace {{ self.namespace }} {
               bool>::type = true>
       Ref(const FieldOwned< {{ td.ty }}, Offset, Offsets... >& f) {
           constexpr bool heap_allocated = __zngur_internal_calc_field<Offset, Offsets...>::heap_allocated();
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
           if (heap_allocated) {
               __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
           } else {
@@ -894,7 +894,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRef< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
 
@@ -920,7 +920,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
     {% endif %}


### PR DESCRIPTION
some missed `const`s, includes a test that would be failing previously

(I’m currently trying to upgrade a real project to a version with variants, so I’ll maybe add more fixes to this branch if I catch anything else)