### PR TITLE
Fix double indirection in field offset calculation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: macos-14
     strategy:
       fail-fast: false
+      matrix:
+        cargo_profile:
+          - debug
+          - release
+    env:
+      EXAMPLES_CARGO_PROFILE: ${{ matrix.cargo_profile }}
     steps:
       - uses: actions/checkout@v3
       - uses: jdx/mise-action@v3
@@ -35,8 +41,12 @@ jobs:
         cpp_compiler:
           - clang++
           - g++
+        cargo_profile:
+          - debug
+          - release
     env:
       CXX: ${{ matrix.cpp_compiler }}
+      EXAMPLES_CARGO_PROFILE: ${{ matrix.cargo_profile }}
     steps:
       - uses: actions/checkout@v3
       - uses: jdx/mise-action@v3
@@ -59,8 +69,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        cargo_profile:
+          - debug
+          - release
     env:
       CXX: g++
+      EXAMPLES_CARGO_PROFILE: ${{ matrix.cargo_profile }}
     steps:
       - uses: actions/checkout@v3
       - uses: jdx/mise-action@v3
@@ -75,6 +90,13 @@ jobs:
 
   build-win:
     runs-on: windows-2022
+    strategy:
+      matrix:
+        cargo_profile:
+          - debug
+          - release
+    env:
+      EXAMPLES_CARGO_PROFILE: ${{ matrix.cargo_profile }}
     steps:
       - name: Turn off autocrlf
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,5 @@ edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 
-[profile.dev]
-opt-level = 3
-
 [profile.release]
 lto = true

--- a/examples/char/Makefile
+++ b/examples/char/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_char.a
-	${CXX} -std=c++11 -Werror -I. main.cpp -g -L ../../target/release/ -l example_char
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_char.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_char.a
+	${CXX} -std=c++11 -Werror -I. main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_char
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_char.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/char/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_char.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_char.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/char/NMakefile
+++ b/examples/char/NMakefile
@@ -1,13 +1,17 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 # MSVC doesn't support earlier that c++14
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++14 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = char
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -15,7 +19,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/enums/Makefile
+++ b/examples/enums/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_enums.a
-	${CXX} -std=c++17 -Werror main.cpp  -g -L ../../target/release/ -l example_enums
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_enums.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_enums.a
+	${CXX} -std=c++17 -Werror main.cpp  -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_enums
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_enums.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/enums/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_enums.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_enums.a generated.h clean
 
 clean:
 	rm -f generated.h src/generated.rs a.out actual_output.txt

--- a/examples/enums/NMakefile
+++ b/examples/enums/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = enums
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/enums/expected_output.txt
+++ b/examples/enums/expected_output.txt
@@ -3,4 +3,6 @@ some 42
 is some
 some 1337
 first: 42
-second: 24
+second: [main.cpp:51] rust::Ref(r->f1) = NonPrimitive(
+    42,
+)

--- a/examples/enums/main.cpp
+++ b/examples/enums/main.cpp
@@ -46,8 +46,9 @@ int main() {
         std::cout << "first: " << r->f0 << std::endl;
     }
     m = Merged::second();
-    if (auto r = Merged::Second::match(m)) {
-        std::cout << "second: " << r->f0 << std::endl;
+    if (auto r = Merged::Second::match_ref(m)) {
+        std::cout << "second: ";
+        zngur_dbg(rust::Ref(r->f1));
     }
 
     Container c = { Merged::first() };

--- a/examples/enums/main.zng
+++ b/examples/enums/main.zng
@@ -21,9 +21,9 @@ mod crate {
         variant First {
             non_exhaustive;
         }
-        // And knows that Second has a 0 field, but not that it's non_exhaustive.
+        // And knows that Second has a 1 field, but not that it's non_exhaustive.
         variant Second {
-            field 0 (offset = auto, type = i32);
+            field 1 (offset = auto, type = NonPrimitive);
         }
 
         fn first() -> Merged;

--- a/examples/enums/second.zng
+++ b/examples/enums/second.zng
@@ -1,4 +1,9 @@
 mod crate {
+    type NonPrimitive {
+        #layout(size = 4, align = 4);
+        wellknown_traits(Debug);
+    }
+
     type Merged {
         #layout(size = 12, align = 4);
         // This file knows that the whole enum is non_exhaustive.

--- a/examples/enums/src/lib.rs
+++ b/examples/enums/src/lib.rs
@@ -1,9 +1,12 @@
 #[rustfmt::skip]
 mod generated;
 
+#[derive(Debug)]
+pub struct NonPrimitive(pub i32);
+
 pub enum Merged {
     First(i32, i32),
-    Second(i32, i32),
+    Second(i32, NonPrimitive),
     Third,
 }
 
@@ -13,7 +16,7 @@ impl Merged {
     }
 
     pub fn second() -> Self {
-        Self::Second(24, 42)
+        Self::Second(24, NonPrimitive(42))
     }
 }
 

--- a/examples/impl_trait/Makefile
+++ b/examples/impl_trait/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_impl_trait.a
-	${CXX} -std=c++20 -Werror main.cpp -g -L ../../target/release/ -l example_impl_trait
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_impl_trait.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_impl_trait.a
+	${CXX} -std=c++20 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_impl_trait
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_impl_trait.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/impl_trait/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_impl_trait.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_impl_trait.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/impl_trait/NMakefile
+++ b/examples/impl_trait/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = impl_trait
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/memory_management/Makefile
+++ b/examples/memory_management/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_memory_management.a
-	${CXX} -std=c++17 -Werror main.cpp generated.cpp -g -L ../../target/release/ -l example_memory_management
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_memory_management.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_memory_management.a
+	${CXX} -std=c++17 -Werror main.cpp generated.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_memory_management
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_memory_management.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h generated.cpp ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/memory_management/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_memory_management.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_memory_management.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/memory_management/NMakefile
+++ b/examples/memory_management/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = memory_management
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp generated.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/multiple_modules/Makefile
+++ b/examples/multiple_modules/Makefile
@@ -1,10 +1,11 @@
+EXAMPLES_CARGO_PROFILE ?= debug
 ZNGUR_CLI = cd ../../zngur-cli && cargo run
 
-a.out: main.cpp aggregation.a packet.zng.h receiver.zng.h aggregation.zng.h processor.zng.h zngur.h ../../target/release/libexample_multiple_modules.a
-	${CXX} -std=c++11 -Werror -I. -Iaggregation main.cpp aggregation.a -g -L ../../target/release/ -l example_multiple_modules
+a.out: main.cpp aggregation.a packet.zng.h receiver.zng.h aggregation.zng.h processor.zng.h zngur.h ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_multiple_modules.a
+	${CXX} -std=c++11 -Werror -I. -Iaggregation main.cpp aggregation.a -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_multiple_modules
 
-../../target/release/libexample_multiple_modules.a:
-	cargo build --release
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_multiple_modules.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 aggregation.a: aggregation/impls.cpp aggregation/generated.cpp aggregation.zng.h zngur.h
 	${CXX} -c -std=c++11 -Werror -I. -Iaggregation -o aggregation/generated.o aggregation/generated.cpp
@@ -39,7 +40,7 @@ processor.zng.h processor/src/processor.zng.rs: processor/processor.zng receiver
 zngur.h:
 	${ZNGUR_CLI} -- make-zng-header ../examples/multiple_modules/zngur.h
 
-.PHONY: ../../target/release/libexample_multiple_modules.a clean run
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_multiple_modules.a clean run
 
 run: a.out
 	./a.out

--- a/examples/overloaded_trait/Makefile
+++ b/examples/overloaded_trait/Makefile
@@ -1,15 +1,16 @@
 NAME = overloaded_trait
+EXAMPLES_CARGO_PROFILE ?= debug
 
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_$(NAME).a
-	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/release/ -l example_$(NAME)
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_$(NAME).a
+	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_$(NAME)
 
-../../target/release/libexample_$(NAME).a:
-	cargo build --release
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_$(NAME).a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(NAME)/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_$(NAME).a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_$(NAME).a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/overloaded_trait/NMakefile
+++ b/examples/overloaded_trait/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = overloaded_trait
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/raw_pointer/Makefile
+++ b/examples/raw_pointer/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_raw_pointer.a
-	${CXX} --std=c++17 -Werror main.cpp -g -L ../../target/release/ -l example_raw_pointer
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_raw_pointer.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_raw_pointer.a
+	${CXX} --std=c++17 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_raw_pointer
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_raw_pointer.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/raw_pointer/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_raw_pointer.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_raw_pointer.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/raw_pointer/NMakefile
+++ b/examples/raw_pointer/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++17 /Zc:__cplusplus # c++17 is needed for panic to exceptions
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = raw_pointer
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/rayon/Makefile
+++ b/examples/rayon/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_rayon.a
-	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/release/ -l example_rayon
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_rayon.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rayon.a
+	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_rayon
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rayon.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/rayon/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_rayon.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rayon.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/rayon/NMakefile
+++ b/examples/rayon/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++14 /Zc:__cplusplus # c++14 is as low as msvc goes
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = rayon
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/rayon_split/Makefile
+++ b/examples/rayon_split/Makefile
@@ -1,8 +1,10 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_rayon_split.a
-	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/release/ -l example_rayon_split -I .
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_rayon_split.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rayon_split.a
+	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_rayon_split -I .
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rayon_split.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng zngur.h
 	cd ../../zngur-cli && cargo run g ../examples/rayon_split/main.zng --crate-name "crate"
@@ -10,7 +12,7 @@ generated.h ./src/generated.rs: main.zng zngur.h
 zngur.h:
 	cd ../../zngur-cli && cargo run h ../examples/rayon_split/zngur.h
 	
-.PHONY: ../../target/release/libexample_rayon_split.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rayon_split.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt zngur.h

--- a/examples/rayon_split/NMakefile
+++ b/examples/rayon_split/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /external:I . /external:W0 /std:c++14 /Zc:__cplusplus # c++14 is as low as msvc goes
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = rayon_split
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH) 
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng zngur.h
 	cd ../../zngur-cli && cargo run g ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/regression_test1/Makefile
+++ b/examples/regression_test1/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_regression_test1.a
-	${CXX} -std=c++20 -Werror main.cpp -g -L ../../target/release/ -l example_regression_test1
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_regression_test1.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_regression_test1.a
+	${CXX} -std=c++20 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_regression_test1
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_regression_test1.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/regression_test1/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_regression_test1.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_regression_test1.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/regression_test1/NMakefile
+++ b/examples/regression_test1/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = regression_test1
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/rustyline/Makefile
+++ b/examples/rustyline/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_rustyline.a
-	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/release/ -l example_rustyline
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_rustyline.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rustyline.a
+	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_rustyline
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rustyline.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/rustyline/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_rustyline.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_rustyline.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/rustyline/NMakefile
+++ b/examples/rustyline/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib User32.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib User32.lib Gdi32.lib
 
 EXAMPLE_NAME = rustyline
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_simple.a
-	${CXX} -std=c++17 -Werror main.cpp generated.cpp -g -L ../../target/release/ -l example_simple
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_simple.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_simple.a
+	${CXX} -std=c++17 -Werror main.cpp generated.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_simple
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_simple.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h generated.cpp ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/simple/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_simple.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_simple.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/simple/NMakefile
+++ b/examples/simple/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = simple
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp generated.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/simple_import/Makefile
+++ b/examples/simple_import/Makefile
@@ -1,10 +1,12 @@
-.PHONY: ../../target/release/libexample_simple_import.a
+EXAMPLES_CARGO_PROFILE ?= debug
 
-a.out: main.cpp foo.cpp bar.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_simple_import.a
-	${CXX} -std=c++11 main.cpp foo.cpp bar.cpp -g -L ../../target/release/ -l example_simple_import
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_simple_import.a
 
-../../target/release/libexample_simple_import.a:
-	cargo build --release
+a.out: main.cpp foo.cpp bar.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_simple_import.a
+	${CXX} -std=c++11 main.cpp foo.cpp bar.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_simple_import
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_simple_import.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng primitives.zng foo.zng bar.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/simple_import/main.zng --crate-name "crate"

--- a/examples/simple_import/NMakefile
+++ b/examples/simple_import/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = simple_import
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp foo.cpp bar.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/examples/stack_owned/Makefile
+++ b/examples/stack_owned/Makefile
@@ -1,6 +1,8 @@
+EXAMPLES_CARGO_PROFILE ?= debug
+
 a.out: src/main.rs build.rs main.zng impls.cpp
-	cargo build
-	cp ../../target/debug/example-stack-owned a.out
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
+	cp ../../target/$(EXAMPLES_CARGO_PROFILE)/example-stack-owned a.out
 
 .PHONY: clean
 clean:

--- a/examples/stack_owned/NMakefile
+++ b/examples/stack_owned/NMakefile
@@ -1,6 +1,10 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 a.exe: src/main.rs build.rs main.zng impls.cpp
-	cargo build
-	copy ..\..\target\debug\example-stack-owned.exe a.exe
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
+	copy ..\..\target\$(EXAMPLES_CARGO_PROFILE)\example-stack-owned.exe a.exe
 
 clean:
 	- del /f /q a.exe actual_output.txt generated.h generated.cpp src\generated.rs 2>nul

--- a/examples/template_types/Makefile
+++ b/examples/template_types/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_template_types.a
-	${CXX} -std=c++20 -Werror -I. main.cpp -g -L ../../target/release/ -l example_template_types
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_template_types.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_template_types.a
+	${CXX} -std=c++20 -Werror -I. main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_template_types
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_template_types.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/template_types/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_template_types.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_template_types.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/tutorial-wasm32/Makefile
+++ b/examples/tutorial-wasm32/Makefile
@@ -1,3 +1,6 @@
+EXAMPLES_CARGO_PROFILE ?= debug
+
+#
 # WASI build flags for C++ compilation with wasmtime
 WASIFLAGS = -std=c++14 \
            --target=wasm32-wasi \
@@ -26,17 +29,17 @@ a.out: main.wasm
 	@chmod +x $@
 
 main.wasm: main.cpp generated.h generated.cpp \
-           ./target/wasm32-wasip1/release/libexample_tutorial_wasm32.a
+           ./target/wasm32-wasip1/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial_wasm32.a
 	$(CXX) $(WASIFLAGS) \
 	    main.cpp generated.cpp \
-	    ./target/wasm32-wasip1/release/libexample_tutorial_wasm32.a \
+	    ./target/wasm32-wasip1/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial_wasm32.a \
 	    -o $@
 
-./target/wasm32-wasip1/release/libexample_tutorial_wasm32.a: wasm32-wasip1-target generated.h ./src/generated.rs ./src/lib.rs
-	cargo build --target=wasm32-wasip1 --release
+./target/wasm32-wasip1/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial_wasm32.a: wasm32-wasip1-target generated.h ./src/generated.rs ./src/lib.rs
+	cargo build --target=wasm32-wasip1 --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs generated.cpp: main32.zng
-	cargo run --release --manifest-path ../../zngur-cli/Cargo.toml g -i main32.zng
+	cargo run --profile $(EXAMPLES_CARGO_PROFILE:debug=dev) --manifest-path ../../zngur-cli/Cargo.toml g -i main32.zng
 
 # Ensure wasm32-wasip1 target is installed
 wasm32-wasip1-target:

--- a/examples/tutorial-wasm32/NMakefile
+++ b/examples/tutorial-wasm32/NMakefile
@@ -1,3 +1,7 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 # can not eval mise after the fact in nmake, must preeval
 WASIFLAGS = -std=c++17 \
            --target=wasm32-wasi \
@@ -21,18 +25,18 @@ a.bat: main.wasm
 	echo wasmtime run --allow-precompiled "%0\..\main.wasm" "$$@" >> $@
 
 main.wasm: main.cpp generated.h generated.cpp \
-           ./target/wasm32-wasip1/release/libexample_tutorial_wasm32.a
+           ./target/wasm32-wasip1/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial_wasm32.a
 	$(CXX) $(WASIFLAGS) \
 	    main.cpp generated.cpp \
-	    ./target/wasm32-wasip1/release/libexample_tutorial_wasm32.a \
+	    ./target/wasm32-wasip1/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial_wasm32.a \
 	    -o $@
 
 
-./target/wasm32-wasip1/release/libexample_tutorial_wasm32.a:  generated.h ./src/generated.rs ./src/lib.rs
-	cargo build --target=wasm32-wasip1 --release
+./target/wasm32-wasip1/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial_wasm32.a:  generated.h ./src/generated.rs ./src/lib.rs
+	cargo build --target=wasm32-wasip1 --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs generated.cpp: main32.zng
-	cargo run --release --manifest-path ../../zngur-cli/Cargo.toml g -i main32.zng
+	cargo run --profile $(EXAMPLES_CARGO_PROFILE:debug=dev) --manifest-path ../../zngur-cli/Cargo.toml g -i main32.zng
 
 clean:
 	cargo clean

--- a/examples/tutorial/Makefile
+++ b/examples/tutorial/Makefile
@@ -1,13 +1,15 @@
-a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/release/libexample_tutorial.a
-	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/release/ -l example_tutorial
+EXAMPLES_CARGO_PROFILE ?= debug
 
-../../target/release/libexample_tutorial.a:
-	cargo build --release
+a.out: main.cpp generated.h src/generated.rs src/lib.rs ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial.a
+	${CXX} -std=c++11 -Werror main.cpp -g -L ../../target/$(EXAMPLES_CARGO_PROFILE)/ -l example_tutorial
+
+../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial.a:
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 generated.h ./src/generated.rs: main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/tutorial/main.zng --crate-name "crate"
 
-.PHONY: ../../target/release/libexample_tutorial.a generated.h clean
+.PHONY: ../../target/$(EXAMPLES_CARGO_PROFILE)/libexample_tutorial.a generated.h clean
 
 clean:
 	rm -f generated.h generated.cpp src/generated.rs a.out actual_output.txt

--- a/examples/tutorial/NMakefile
+++ b/examples/tutorial/NMakefile
@@ -1,12 +1,16 @@
+!IFNDEF EXAMPLES_CARGO_PROFILE
+EXAMPLES_CARGO_PROFILE = debug
+!ENDIF
+
 CXX = cl.exe
 CXXFLAGS = /W4 /DEBUG /EHsc /std:c++20 /Zc:__cplusplus
-WINLIBS = ntdll.lib
+WINLIBS = ntdll.lib Ws2_32.lib Userenv.lib
 
 EXAMPLE_NAME = tutorial
 
 GENERATED = generated.h src/generated.rs
 
-RUSTLIB_PATH = ../../target/release/
+RUSTLIB_PATH = ../../target/$(EXAMPLES_CARGO_PROFILE)/
 
 RUSTLIB = example_$(EXAMPLE_NAME).lib
 
@@ -14,7 +18,7 @@ a.exe : main.cpp src/lib.rs $(GENERATED) $(RUSTLIB_PATH)/$(RUSTLIB)
 	$(CXX) $(CXXFLAGS) main.cpp /Fe:a.exe /link $(WINLIBS) $(RUSTLIB) /LIBPATH:$(RUSTLIB_PATH)
 
 $(RUSTLIB_PATH)/$(RUSTLIB) :
-	cargo build --release
+	cargo build --profile $(EXAMPLES_CARGO_PROFILE:debug=dev)
 
 $(GENERATED) : main.zng
 	cd ../../zngur-cli && cargo run g -i ../examples/$(EXAMPLE_NAME)/main.zng --crate-name "crate"

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -17,6 +17,12 @@ fn check_book_formatting() -> Result<()> {
 
 fn check_examples(sh: &Shell, fix: bool) -> Result<()> {
     const CARGO_PROJECTS: &[&str] = &["cxx_demo", "tutorial_cpp", "unsafe_fns"];
+    let profile = std::env::var("EXAMPLES_CARGO_PROFILE").ok();
+    // Default to debug; translate debug to dev.
+    let (profile, target_dir) = match profile.as_deref() {
+        None | Some("debug") => ("dev", "debug"),
+        Some(other) => (other, other),
+    };
     let examples_dir = sh.current_dir().join("examples");
     sh.change_dir("examples");
     let examples = sh.read_dir(".")?;
@@ -39,12 +45,12 @@ fn check_examples(sh: &Shell, fix: bool) -> Result<()> {
                     "rm -f generated.h generated.cpp src/generated.rs actual_output.txt"
                 )
                 .run();
-                cmd!(sh, "cargo build")
+                cmd!(sh, "cargo build --profile {profile}")
                     .run()
                     .with_context(|| format!("Building example `{example}` failed"))?;
 
                 let bash_cmd = format!(
-                    "../../target/debug/example-{example} 2>&1 | sed -e s/thread.*\\(.*\\)/thread/g > actual_output.txt"
+                    "../../target/{target_dir}/example-{example} 2>&1 | sed -e s/thread.*\\(.*\\)/thread/g > actual_output.txt"
                 );
                 cmd!(sh, "bash -c {bash_cmd}")
                     .run()
@@ -58,11 +64,13 @@ fn check_examples(sh: &Shell, fix: bool) -> Result<()> {
                     "cmd /c 'del /f /q generated.h generated.cpp src\\generated.rs actual_output.txt 2>nul'"
                 )
                 .run();
-                cmd!(sh, "cmd /c 'cargo build'")
+                let batch_cmd = format!("cargo build --profile {profile}");
+                cmd!(sh, "cmd /c {batch_cmd}")
                     .run()
                     .with_context(|| format!("Building example `{example}` failed"))?;
-                let batch_cmd =
-                    format!("..\\..\\target\\debug\\example-{example} > actual_output.txt 2>&1");
+                let batch_cmd = format!(
+                    "..\\..\\target\\{target_dir}\\example-{example} > actual_output.txt 2>&1"
+                );
                 cmd!(sh, "cmd /c {batch_cmd}")
                     .run()
                     .with_context(|| format!("Running example `{example}` failed"))?;

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -545,7 +545,7 @@ namespace {{ self.namespace }} {
     {% if !td.layout.is_stack_allocated() %}
       return const_cast<uint8_t*>(t.__zngur_data);
     {% else %}
-      return const_cast<uint8_t*>(t.__zngur_data.data());
+      return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&t.__zngur_data));
     {% endif %}
   }
 

--- a/zngur-generator/templates/cpp_header.sptl
+++ b/zngur-generator/templates/cpp_header.sptl
@@ -697,7 +697,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       RefMut(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
     {% endif %}
@@ -894,7 +894,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRef< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
 
@@ -920,7 +920,7 @@ namespace {{ self.namespace }} {
               !zngur_detail::all_static_offset<Offset, Offsets...>::value,
               bool>::type = true>
       Ref(const FieldRefMut< {{ td.ty }}, Offset, Offsets...>& f) {
-          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(reinterpret_cast<const uint8_t*>(&f));
+          size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
           __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
       }
     {% endif %}

--- a/zngur-generator/templates/zng_header.sptl
+++ b/zngur-generator/templates/zng_header.sptl
@@ -413,7 +413,7 @@ namespace {{ self.cpp_namespace }} {
   template<>
   struct __zngur_internal< ::{{ self.cpp_namespace }}::Unit > {
     static inline uint8_t* data_ptr(const ::{{ self.cpp_namespace }}::Unit& t) noexcept {
-        return const_cast<uint8_t*>(t.__zngur_data.data());
+        return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&t.__zngur_data));
     }
     static inline void check_init(const ::{{ self.cpp_namespace }}::Unit&) noexcept {}
     static inline void assume_init(::{{ self.cpp_namespace }}::Unit&) noexcept {}

--- a/zngur-generator/templates/zng_header.sptl
+++ b/zngur-generator/templates/zng_header.sptl
@@ -450,7 +450,7 @@ namespace {{ self.cpp_namespace }} {
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     RefMut(const FieldRefMut< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
   };
@@ -496,7 +496,7 @@ namespace {{ self.cpp_namespace }} {
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldRef< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
@@ -506,7 +506,7 @@ namespace {{ self.cpp_namespace }} {
     }
     template <typename Offset, typename... Offsets, typename ::std::enable_if<!zngur_detail::all_static_offset<Offset, Offsets...>::value, bool>::type = true>
     Ref(const FieldRefMut< ::{{ self.cpp_namespace }}::Unit, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
   };
@@ -626,7 +626,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     {{ ref_kind }}(const FieldRef< {{ nested_ref_kind }} < T >, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
     {% endif %}
@@ -653,7 +653,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     {{ ref_kind }}(const FieldRefMut< {{ nested_ref_kind }} < T >, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -812,7 +812,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     Ref(const FieldRef< {{ ty }}, Offset, Offsets...>& f) {
-        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+        size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
         __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -838,7 +838,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     Ref(const FieldRefMut< {{ ty }}, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 
@@ -925,7 +925,7 @@ namespace {{ self.cpp_namespace }} {
             !zngur_detail::all_static_offset<Offset, Offsets...>::value,
             bool>::type = true>
     RefMut(const FieldRefMut< {{ ty }}, Offset, Offsets...>& f) {
-      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f)); // SCARY
+      size_t offset = __zngur_internal_calc_field<Offset, Offsets...>::offset(*reinterpret_cast<const uint8_t* const*>(&f));
       __zngur_data = *reinterpret_cast<const size_t*>(&f) + offset;
     }
 


### PR DESCRIPTION
sorry, part 2 of variant fixes

this was already fixed for primitive types, but not for user-defined types. ideally, we should remove all the code duplication around field offsets, but I don’t yet have courage to attempt such a refactoring.

additionally this:
- removes SCARY comments that marked the place fixing that exact bug for primitives
- changes `examples/enums` to build in debug so that `unreachable_unchecked()` in field offset calculation actually triggers a panic
- uses that to make `examples/enums` test catch this bug